### PR TITLE
TeleportToPosition Lua Function and Text Wrapping on TabStrings

### DIFF
--- a/RogueEssence.Editor.Avalonia/Views/GroundEditForm/GroundTabStrings.axaml
+++ b/RogueEssence.Editor.Avalonia/Views/GroundEditForm/GroundTabStrings.axaml
@@ -21,7 +21,7 @@
       <ColumnDefinition/>
       <ColumnDefinition/>
     </Grid.ColumnDefinitions>
-    <TextBlock Margin="4" VerticalAlignment="Bottom" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="5">Add, edit, or remove localized strings to be used by scripts on the map.</TextBlock>
+    <TextBlock Margin="4" VerticalAlignment="Bottom" TextWrapping="Wrap" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="5">Add, edit, or remove localized strings to be used by scripts on the map.</TextBlock>
     <DataGrid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" Items="{Binding MapStrings}" SelectedIndex="{Binding CurrentString, Mode=TwoWay}">
       <DataGrid.Columns>
         <DataGridTextColumn Header="Key" Binding="{Binding Key}"/>

--- a/RogueEssence/Lua/ScriptGround.cs
+++ b/RogueEssence/Lua/ScriptGround.cs
@@ -643,6 +643,34 @@ namespace RogueEssence.Script
             }
             return null;
         }
+        
+        /// <summary>
+        /// Teleports an entity to the selected position.
+        /// </summary>
+        /// <param name="ent"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public LuaFunction TeleportToPosition;
+        public void _TeleportToPosition(GroundEntity ent, int x, int y)
+        {
+            try
+            {
+                if (ent is GroundChar)
+                {
+                    GroundChar ch = (GroundChar)ent;
+                    ch.Position = Loc(x,y)
+                }
+
+                throw new ArgumentException("Entity is not a valid type.");
+
+            }
+            catch (Exception ex)
+            {
+                DiagManager.Instance.LogError(ex, DiagManager.Instance.DevMode);
+            }
+            return null;
+        }
 
         /// <summary>
         /// Makes an entity move to a marker.
@@ -674,6 +702,7 @@ namespace RogueEssence.Script
 
             MoveToMarker = state.RunString("return function(_, ent, mark, shouldrun, speed) return coroutine.yield(GROUND:_MoveToMarker(ent, mark, shouldrun, speed)) end", "MoveToMarker").First() as LuaFunction;
             MoveToPosition = state.RunString("return function(_, ent, x, y, shouldrun, speed) return coroutine.yield(GROUND:_MoveToPosition(ent, x, y, shouldrun, speed)) end", "MoveToPosition").First() as LuaFunction;
+            TeleportToPosition = state.RunString("return function(_, ent, x, y) return GROUND:_TeleportToPosition(ent, x, y) end", "TeleportToPosition").First() as LuaFunction;
             AnimateToPosition = state.RunString("return function(_, ent, anim, animdir, x, y, animspeed, speed) return coroutine.yield(GROUND:_AnimateToPosition(ent, anim, animdir, x, y, animspeed, speed)) end", "AnimateToPosition").First() as LuaFunction;
             CharWaitAction = state.RunString("return function(_, ent, action) return coroutine.yield(GROUND:_CharWaitAction(ent, action)) end", "CharWaitAction").First() as LuaFunction;
         }


### PR DESCRIPTION
This pull request contains two commits.

The first commit adds a new lua function, namely TeleportToPosition, which allows the user to set the position of an entity with no yield. This is a simpler version of MoveToPosition without needing to animate or yield.

The second commit addresses this [issue](https://github.com/audinowho/PMDODump/issues/9#issue-1104076344) where the request is that the text wraps in the TabStrings DataGrid for the ground map editor. This small property flag should make it easier for users to view long text strings in a paragraph format.

At your next convenience, please verify my branch additions are useful and operational.