### PR TITLE
Add option to delete tilesets in editor

### DIFF
--- a/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowser.axaml
+++ b/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowser.axaml
@@ -23,6 +23,7 @@
     <Grid.RowDefinitions>
       <RowDefinition Height="11*"/>
       <RowDefinition Height="9*"/>
+      <RowDefinition Height="40"/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
       <ColumnDefinition MinWidth="400" Width="2*"/>
@@ -67,7 +68,7 @@
         <Button Command="{Binding btnDeleteFrame_Click}" Margin="4,2" Grid.Row="3" Grid.Column="1">Delete</Button>
       </Grid>
     </Grid>
-    <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" Grid.Row="0" Grid.Column="0" Grid.RowSpan="2">
+    <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" Grid.Row="0" Grid.Column="0" Grid.RowSpan="3">
       <Grid>
         <Image Source="{Binding CurrentTileset, Converter={StaticResource TilesetConverter}}" PointerPressed="picTileset_Click" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0"/>
         <Border VerticalAlignment="Top" HorizontalAlignment="Left" IsVisible="{Binding BorderPresent}" BorderThickness="1" BorderBrush="Red">
@@ -93,5 +94,6 @@
       </Grid>
     </ScrollViewer>
     <views:SearchListBox DataContext="{Binding Tilesets}" Margin="4" Grid.Row="1" Grid.Column="1"/>
+    <Button Command="{Binding btnDeleteTileset}" Margin="4" Grid.Row="2" Grid.Column="1">Delete Selected Tileset</Button>
   </Grid>
 </UserControl>


### PR DESCRIPTION
![Screenshot_20220904_235754](https://user-images.githubusercontent.com/8182590/188383979-b8f89900-71c7-449b-ac6a-0dd6f8da114c.png)
This Adds the functionality to delete already imported tilesets in the ground editor.