### PR TITLE
Unrecruitable flag is now specific to the pokemon, rather than the team

### DIFF
--- a/RogueEssence/Data/BattleData.cs
+++ b/RogueEssence/Data/BattleData.cs
@@ -42,7 +42,7 @@ namespace RogueEssence.Data
         public override string ToString()
         {
             ElementData element = DataManager.Instance.GetElement(Element);
-            string type = Text.FormatKey("MENU_SKILLS_ELEMENT", element.Name.ToLocal());
+            string type = Text.FormatKey("MENU_SKILLS_ELEMENT", element != null ? element.Name.ToLocal() : "---");
             string category = Text.FormatKey("MENU_SKILLS_CATEGORY", Category.ToLocal());
             BasePowerState powerState = SkillStates.GetWithDefault<BasePowerState>();
             string power = Text.FormatKey("MENU_SKILLS_POWER", (powerState != null ? powerState.Power.ToString() : "---"));

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -298,6 +298,7 @@ namespace RogueEssence.Dungeon
         public bool SeeItems;
         public bool SeeWallItems;
         public bool SeeTraps;
+        public bool Unrecruitable;
 
         //miscellaneous traits
         public StateCollection<CharState> CharStates;

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -1304,7 +1304,55 @@ namespace RogueEssence.Dungeon
 
         public List<string> GetRelearnableSkills()
         {
-            BaseMonsterForm entry = DataManager.Instance.GetMonster(BaseForm.Species).Forms[BaseForm.Form];
+            List<BaseMonsterForm> entries = new List<BaseMonsterForm>();
+            string evolutionStage = BaseForm.Species;
+            MonsterData entryData;
+            BaseMonsterForm entryForm;
+
+            while (!string.IsNullOrEmpty(evolutionStage))
+            {
+                entryData = DataManager.Instance.GetMonster(evolutionStage);
+                entryForm = entryData.Forms[BaseForm.Form];
+                entries.Add(entryForm);
+                evolutionStage = entryData.PromoteFrom;
+            }
+
+            List<string> forgottenSkills = new List<string>();
+            foreach(BaseMonsterForm entry in entries)
+            {
+                foreach (string skill in entry.GetSkillsAtLevel(Level, true))
+                {
+                    bool hasSkill = false;
+                    foreach (SlotSkill learnedSkill in BaseSkills)
+                    {
+                        if (learnedSkill.SkillNum == skill)
+                        {
+                            hasSkill = true;
+                            break;
+                        }
+                    }
+                    if (!hasSkill && !forgottenSkills.Contains(skill))
+                        forgottenSkills.Add(skill);
+                }
+            }
+
+            foreach (string key in Relearnables.Keys)
+            {
+                bool hasSkill = false;
+                foreach (SlotSkill learnedSkill in BaseSkills)
+                {
+                    if (learnedSkill.SkillNum == key)
+                    {
+                        hasSkill = true;
+                        break;
+                    }
+                }
+                if (!hasSkill && !forgottenSkills.Contains(key))
+                    forgottenSkills.Add(key);
+            }
+            return forgottenSkills;
+
+            /*BaseMonsterForm entry = DataManager.Instance.GetMonster(BaseForm.Species).Forms[BaseForm.Form];
             List<string> forgottenSkills = new List<string>();
             foreach (string skill in entry.GetSkillsAtLevel(Level, true))
             {
@@ -1335,7 +1383,7 @@ namespace RogueEssence.Dungeon
                 if (!hasSkill && !forgottenSkills.Contains(key))
                     forgottenSkills.Add(key);
             }
-            return forgottenSkills;
+            return forgottenSkills;*/
         }
 
         public IEnumerator<YieldInstruction> ChangeElement(string element1, string element2, bool msg = true, bool vfx = true)

--- a/RogueEssence/Dungeon/Team.cs
+++ b/RogueEssence/Dungeon/Team.cs
@@ -324,7 +324,6 @@ namespace RogueEssence.Dungeon
     [Serializable]
     public class MonsterTeam : Team
     {
-        public bool Unrecruitable;
 
         public MonsterTeam() : this(true)
         { }
@@ -338,7 +337,7 @@ namespace RogueEssence.Dungeon
 
         protected MonsterTeam(MonsterTeam other) : base(other)
         {
-            Unrecruitable = other.Unrecruitable;
+            
         }
 
         public override Team Clone() { return new MonsterTeam(this); }


### PR DESCRIPTION
- Can also now relearn moves from pre-evolution(s)
- Fixed NullReferenceException in RogueEssence.Data.BattleData.ToString()