### PR TITLE
Add a verify replay option in the replay menu.

### DIFF
--- a/RogueEssence/Data/DataManager.cs
+++ b/RogueEssence/Data/DataManager.cs
@@ -88,7 +88,8 @@ namespace RogueEssence.Data
         {
             None,
             Loading,
-            Rescuing
+            Rescuing,
+            Verifying
         }
 
         private static DataManager instance;

--- a/RogueEssence/Menu/Records/ReplayChosenMenu.cs
+++ b/RogueEssence/Menu/Records/ReplayChosenMenu.cs
@@ -83,7 +83,7 @@ namespace RogueEssence.Menu
 
             // By setting LoadMode to Loading, the game speed will be at its max and show us the results
             // from the replay.
-            DataManager.Instance.Loading = DataManager.LoadMode.Loading;
+            DataManager.Instance.Loading = DataManager.LoadMode.Verifying;
             GameManager.Instance.SceneOutcome = Replay(replay);
         }
 

--- a/RogueEssence/Menu/Records/ReplayChosenMenu.cs
+++ b/RogueEssence/Menu/Records/ReplayChosenMenu.cs
@@ -71,7 +71,7 @@ namespace RogueEssence.Menu
                 TitleScene.TitleMenuSaveState = MenuManager.Instance.SaveMenuState();
 
                 MenuManager.Instance.ClearMenus();
-                GameManager.Instance.SceneOutcome = Replay(replay);
+                GameManager.Instance.SceneOutcome = Replay(replay, false);
             }
         }
 
@@ -81,10 +81,8 @@ namespace RogueEssence.Menu
 
             MenuManager.Instance.ClearMenus();
 
-            // By setting LoadMode to Loading, the game speed will be at its max and show us the results
-            // from the replay.
-            DataManager.Instance.Loading = DataManager.LoadMode.Verifying;
-            GameManager.Instance.SceneOutcome = Replay(replay);
+            // Play the replay with LoadMode set to Verifying
+            GameManager.Instance.SceneOutcome = Replay(replay, true);
         }
 
         private void SeedAction()
@@ -133,12 +131,17 @@ namespace RogueEssence.Menu
             MenuManager.Instance.RemoveMenu();
         }
 
-        public IEnumerator<YieldInstruction> Replay(ReplayData replay)
+        public IEnumerator<YieldInstruction> Replay(ReplayData replay, Boolean is_verifying)
         {
             GameManager.Instance.BGM("", true);
             yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.FadeOut(false));
 
             DataManager.Instance.MsgLog.Clear();
+
+            if (is_verifying) 
+            {
+                DataManager.Instance.Loading = DataManager.LoadMode.Verifying;
+            }
 
             if (replay.States.Count > 0)
             {

--- a/RogueEssence/Menu/Records/ReplayChosenMenu.cs
+++ b/RogueEssence/Menu/Records/ReplayChosenMenu.cs
@@ -25,6 +25,7 @@ namespace RogueEssence.Menu
             
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_INFO"), SummaryAction));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_REPLAY"), ReplayAction));
+            choices.Add(new MenuTextChoice("CONTINUE ACTION", ProofAction));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_SEED"), SeedAction));
 
             if (DataManager.Instance.GetRecordHeader(recordDir).IsFavorite)
@@ -70,8 +71,67 @@ namespace RogueEssence.Menu
                 TitleScene.TitleMenuSaveState = MenuManager.Instance.SaveMenuState();
 
                 MenuManager.Instance.ClearMenus();
-                GameManager.Instance.SceneOutcome = Replay(replay);
+                GameManager.Instance.SceneOutcome = ReplayQuickSave(replay);
             }
+        }
+
+        private void ProofAction() {
+
+            ReplayData replay = DataManager.Instance.LoadReplay(recordDir, false);
+
+            MenuManager.Instance.ClearMenus();
+            GameManager.Instance.SceneOutcome = ReplayQuickSave(replay);
+        }
+
+        private IEnumerator<YieldInstruction> ReplayQuickSave(ReplayData replay)
+        {
+            GameManager.Instance.BGM("", true);
+            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.FadeOut(false));
+
+            DataManager.Instance.MsgLog.Clear();
+            GameState state = replay.ReadState();
+            DataManager.Instance.SetProgress(state.Save);
+            LuaEngine.Instance.LoadSavedData(DataManager.Instance.Save); //notify script engine
+            ZoneManager.LoadFromState(state.Zone);
+            LuaEngine.Instance.UpdateZoneInstance();
+
+            //NOTE: In order to preserve debug consistency, you SHOULD set the language to that of the quicksave.
+            //HOWEVER, it would be too inconvenient for players sharing their quicksaves, thus this feature is LEFT OUT.
+
+            DataManager.Instance.Loading = DataManager.LoadMode.Loading;
+
+            DataManager.Instance.CurrentReplay = replay;
+
+
+            if (DataManager.Instance.Save.NextDest.IsValid())
+            {
+                yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.Save.NextDest));
+            }
+            else
+            {
+                DataManager.Instance.ResumePlay(DataManager.Instance.CurrentReplay);
+                DataManager.Instance.CurrentReplay = null;
+                DataManager.Instance.Save.UpdateOptions();
+
+                GameManager.Instance.SetFade(true, false);
+
+                DataManager.Instance.Loading = DataManager.LoadMode.None;
+
+                if (ZoneManager.Instance.CurrentMapID.Segment > -1)
+                {
+                    GameManager.Instance.MoveToScene(DungeonScene.Instance);
+                    GameManager.Instance.BGM(ZoneManager.Instance.CurrentMap.Music, true);
+                    yield return CoroutineManager.Instance.StartCoroutine(DungeonScene.Instance.InitFloor());
+                }
+                else
+                {
+                    GameManager.Instance.MoveToScene(Ground.GroundScene.Instance);
+                    GameManager.Instance.BGM(ZoneManager.Instance.CurrentGround.Music, true);
+                    yield return CoroutineManager.Instance.StartCoroutine(Ground.GroundScene.Instance.InitGround(false));
+                }
+
+                yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.FadeIn());
+            } 
         }
 
         private void SeedAction()

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -797,7 +797,13 @@ namespace RogueEssence
                         if (nextAction.Type == GameAction.ActionType.Rescue)
                             rescued = nextAction;
                         else if (result != GameProgress.ResultType.Unknown)//we shouldn't be hitting this point!  give an error notification!
-                            yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.SetDialogue(Text.FormatKey("DLG_REPLAY_DESYNC")));
+                            
+                            // Change dialogue message depending on the LoadMode.
+                            if (DataManager.Instance.Loading != DataManager.LoadMode.Verifying) {
+                                yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.SetDialogue(Text.FormatKey("DLG_REPLAY_DESYNC")));
+                            } else {
+                                yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.SetDialogue(Text.FormatKey("DLG_REPLAY_VERIFY_DESYNC")));
+                            }
                     }
 
                     if (rescued != null) //run the action
@@ -858,6 +864,12 @@ namespace RogueEssence
                             //if failed, just show the death plaque
                             //if succeeded, run the script that follows.
                             SceneOutcome = ZoneManager.Instance.CurrentZone.OnExitSegment(result, rescuing);
+                        }
+                        else if (DataManager.Instance.Loading == DataManager.LoadMode.Verifying) {
+
+                            Console.WriteLine("Verified");
+                            yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.SetDialogue(Text.FormatKey("DLG_REPLAY_VERIFY_OK")));
+                            yield return CoroutineManager.Instance.StartCoroutine(EndReplay());
                         }
                         else //we've reached the end of the replay
                             yield return CoroutineManager.Instance.StartCoroutine(EndReplay());

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -865,9 +865,8 @@ namespace RogueEssence
                             //if succeeded, run the script that follows.
                             SceneOutcome = ZoneManager.Instance.CurrentZone.OnExitSegment(result, rescuing);
                         }
-                        else if (DataManager.Instance.Loading == DataManager.LoadMode.Verifying) {
-
-                            Console.WriteLine("Verified");
+                        else if (DataManager.Instance.Loading == DataManager.LoadMode.Verifying) 
+                        {
                             yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.SetDialogue(Text.FormatKey("DLG_REPLAY_VERIFY_OK")));
                             yield return CoroutineManager.Instance.StartCoroutine(EndReplay());
                         }


### PR DESCRIPTION
This PR adds the ability to quickly verify the selected replay by setting `DataManager.Instance.Loading` to `Loading`, and then loading it as a replay.

A new PR will be made for DumpAssets which adds the string for MENU_REPLAY_VERIFY