### PR TITLE
Add Learnset menu

### DIFF
--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -91,7 +91,7 @@ namespace RogueEssence.Menu
             return box.ToArray();
         }
 
-        protected void SetPage(int page)
+        protected virtual void SetPage(int page)
         {
             CurrentPage = page;
             if (TotalChoices.Length == 1 && !ShowPagesOnSingle)

--- a/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
+++ b/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
@@ -145,7 +145,7 @@ namespace RogueEssence.Menu
             else if (IsInputting(input, Dir8.Left))
             {
                 GameManager.Instance.SE("Menu/Skip");
-                MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot, assembly, allowAssembly));
+                MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot, assembly, allowAssembly, true));
             }
             else if (IsInputting(input, Dir8.Right))
             {

--- a/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
+++ b/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
@@ -13,6 +13,7 @@ namespace RogueEssence.Menu
         int teamSlot;
         bool assembly;
         bool allowAssembly;
+
         public MenuText Title;
         public MenuDivider Div;
 
@@ -31,7 +32,6 @@ namespace RogueEssence.Menu
         public MenuDivider IntrinsicDiv;
         public MenuText Intrinsic;
         public DialogueText IntrinsicDesc;
-
         public MemberFeaturesMenu(int teamSlot, bool assembly, bool allowAssembly)
         {
             Bounds = Rect.FromPoints(new Loc(24, 16), new Loc(296, 224));
@@ -41,9 +41,16 @@ namespace RogueEssence.Menu
             this.allowAssembly = allowAssembly;
 
             Character player = assembly ? DataManager.Instance.Save.ActiveTeam.Assembly[teamSlot] : DataManager.Instance.Save.ActiveTeam.Players[teamSlot];
+            
+            MonsterData dexEntry = DataManager.Instance.GetMonster(player.BaseForm.Species);
+            BaseMonsterForm formEntry = dexEntry.Forms[player.BaseForm.Form];
+            
+            int totalLearnsetPages = (int) Math.Ceiling((double) formEntry.LevelSkills.Count / MemberLearnsetMenu.SLOTS_PER_PAGE);
+            int totalOtherMemberPages = 3;
+            int totalPages = totalLearnsetPages + totalOtherMemberPages; 
 
             //TODO: align this text properly
-            Title = new MenuText(Text.FormatKey("MENU_TEAM_FEATURES") + " (1/3)", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
+            Title = new MenuText(Text.FormatKey("MENU_TEAM_FEATURES") + $" (1/{totalPages})", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
             Div = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + LINE_HEIGHT), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
 
             Portrait = new SpeakerPortrait(player.BaseForm, new EmoteStyle(0),
@@ -90,7 +97,7 @@ namespace RogueEssence.Menu
             }
 
             IntrinsicDiv = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 10), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
-
+            
             bool origIntrinsic = (player.Intrinsics[0].Element.ID == player.BaseIntrinsics[0]);
             IntrinsicData entry = DataManager.Instance.GetIntrinsic(player.Intrinsics[0].Element.ID);
             Intrinsic = new MenuText(Text.FormatKey("MENU_TEAM_INTRINSIC", entry.GetColoredName()), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 9 + TitledStripMenu.TITLE_OFFSET), origIntrinsic ? Color.White : Color.Yellow);
@@ -138,7 +145,7 @@ namespace RogueEssence.Menu
             else if (IsInputting(input, Dir8.Left))
             {
                 GameManager.Instance.SE("Menu/Skip");
-                MenuManager.Instance.ReplaceMenu(new MemberInfoMenu(teamSlot, assembly, allowAssembly));
+                MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot, assembly, allowAssembly));
             }
             else if (IsInputting(input, Dir8.Right))
             {

--- a/RogueEssence/Menu/Team/MemberInfoMenu.cs
+++ b/RogueEssence/Menu/Team/MemberInfoMenu.cs
@@ -144,7 +144,7 @@ namespace RogueEssence.Menu
             else if (IsInputting(input, Dir8.Right))
             {
                 GameManager.Instance.SE("Menu/Skip");
-                MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot, assembly, allowAssembly));
+                MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot, assembly, allowAssembly, false));
             }
             else if (IsInputting(input, Dir8.Up))
             {

--- a/RogueEssence/Menu/Team/MemberInfoMenu.cs
+++ b/RogueEssence/Menu/Team/MemberInfoMenu.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using RogueElements;
 using Microsoft.Xna.Framework;
 using RogueEssence.Content;
@@ -12,6 +13,7 @@ namespace RogueEssence.Menu
         int teamSlot;
         bool assembly;
         bool allowAssembly;
+        
         public MenuText Title;
         public MenuDivider Div;
 
@@ -34,14 +36,18 @@ namespace RogueEssence.Menu
             this.allowAssembly = allowAssembly;
 
             Character player = assembly ? DataManager.Instance.Save.ActiveTeam.Assembly[teamSlot] : DataManager.Instance.Save.ActiveTeam.Players[teamSlot];
-
-            //TODO: align the page text properly
-            Title = new MenuText(Text.FormatKey("MENU_TEAM_INFO") +" (3/3)", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
-            Div = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + LINE_HEIGHT), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
-
-
+            
             MonsterData dexEntry = DataManager.Instance.GetMonster(player.BaseForm.Species);
             BaseMonsterForm formEntry = dexEntry.Forms[player.BaseForm.Form];
+            
+            int totalLearnsetPages = (int) Math.Ceiling((double) formEntry.LevelSkills.Count / MemberLearnsetMenu.SLOTS_PER_PAGE);
+            int totalOtherMemberPages = 3;
+            int totalPages = totalLearnsetPages + totalOtherMemberPages;
+
+            //TODO: align the page text properly
+            Title = new MenuText(Text.FormatKey("MENU_TEAM_INFO") + $" (3/{totalPages})", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
+            Div = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + LINE_HEIGHT), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
+
             Portrait = new SpeakerPortrait(player.BaseForm, new EmoteStyle(0),
                 new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + TitledStripMenu.TITLE_OFFSET), false);
 
@@ -138,7 +144,7 @@ namespace RogueEssence.Menu
             else if (IsInputting(input, Dir8.Right))
             {
                 GameManager.Instance.SE("Menu/Skip");
-                MenuManager.Instance.ReplaceMenu(new MemberFeaturesMenu(teamSlot, assembly, allowAssembly));
+                MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot, assembly, allowAssembly));
             }
             else if (IsInputting(input, Dir8.Up))
             {

--- a/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
+++ b/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework.Graphics;
+using RogueEssence.Content;
+using RogueElements;
+using RogueEssence.Data;
+using Microsoft.Xna.Framework;
+using RogueEssence.Dungeon;
+
+namespace RogueEssence.Menu
+{
+    public class MemberLearnsetMenu : MultiPageMenu
+    {
+        public static readonly int SLOTS_PER_PAGE = 6;
+        private List<string> Skills = new List<string>();
+
+        int teamSlot;
+        bool assembly;
+        bool allowAssembly;
+
+        SkillSummary summaryMenu;
+
+        public MemberLearnsetMenu(int teamSlot, bool assembly, bool allowAssembly)
+        {
+            this.teamSlot = teamSlot;
+            this.assembly = assembly;
+            this.allowAssembly = allowAssembly;
+
+            Character player = assembly
+                ? DataManager.Instance.Save.ActiveTeam.Assembly[teamSlot]
+                : DataManager.Instance.Save.ActiveTeam.Players[teamSlot];
+            
+            MonsterData dexEntry = DataManager.Instance.GetMonster(player.BaseForm.Species);
+            BaseMonsterForm formEntry = dexEntry.Forms[player.BaseForm.Form];
+            
+            List<MenuChoice> flatChoices = new List<MenuChoice>();
+            foreach (LevelUpSkill levelUpSkill in formEntry.LevelSkills)
+            {
+                string skill = levelUpSkill.Skill;
+                SkillData skillEntry = DataManager.Instance.GetSkill(levelUpSkill.Skill);
+
+                MenuText skillText = new MenuText(skillEntry.GetIconName(), new Loc(1, 1), Color.White);
+                MenuText levelUpText = new MenuText(levelUpSkill.Level.ToString(),
+                    new Loc(GraphicsManager.ScreenWidth - 72, 1), DirV.Up, DirH.Right, Color.White);
+
+                Skills.Add(skill);
+                flatChoices.Add(new MenuElementChoice(() => { }, true, levelUpText, skillText));
+            }
+
+            IChoosable[][] choices = SortIntoPages(flatChoices.ToArray(), SLOTS_PER_PAGE);
+
+            summaryMenu = new SkillSummary(Rect.FromPoints(new Loc(16,
+                    GraphicsManager.ScreenHeight - 8 - GraphicsManager.MenuBG.TileHeight * 2 - LINE_HEIGHT * 2 -
+                    VERT_SPACE * 4),
+                new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8)));
+
+            Initialize(new Loc(16, 16), GraphicsManager.ScreenWidth - 32, "", choices, 0, 0, SLOTS_PER_PAGE);
+        }
+
+        protected override void ChoiceChanged()
+        {
+            Title.SetText(Text.FormatKey("MENU_TEAM_LEARNSET",
+                DataManager.Instance.Save.ActiveTeam.Players[teamSlot].GetDisplayName(true)));
+            summaryMenu.SetSkill(Skills[CurrentChoiceTotal]);
+            base.ChoiceChanged();
+        }
+        
+        protected override void UpdateKeys(InputManager input)
+        {
+            if (CurrentPage - 1 == -1 && IsInputting(input, Dir8.Left))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                MenuManager.Instance.ReplaceMenu(new MemberInfoMenu(teamSlot, assembly, allowAssembly));
+            }
+
+            else if (CurrentPage + 1 == TotalChoices.Length && IsInputting(input, Dir8.Right))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                MenuManager.Instance.ReplaceMenu(new MemberFeaturesMenu(teamSlot, assembly, allowAssembly));
+            }
+            
+            else if (CurrentChoice - 1 == -1 && IsInputting(input, Dir8.Up))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                if (allowAssembly)
+                {
+                    int amtLimit = (!assembly) ? DataManager.Instance.Save.ActiveTeam.Assembly.Count : DataManager.Instance.Save.ActiveTeam.Players.Count;
+                    if (teamSlot - 1 < 0)
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(amtLimit - 1, !assembly, allowAssembly));
+                    else
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot - 1, assembly, allowAssembly));
+                }
+                else
+                    MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu((teamSlot + DataManager.Instance.Save.ActiveTeam.Players.Count - 1) % DataManager.Instance.Save.ActiveTeam.Players.Count, false, allowAssembly));
+            }
+        
+            else if (CurrentChoice + 1 == SLOTS_PER_PAGE && IsInputting(input, Dir8.Down))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                if (allowAssembly)
+                {
+                    int amtLimit = assembly ? DataManager.Instance.Save.ActiveTeam.Assembly.Count : DataManager.Instance.Save.ActiveTeam.Players.Count;
+                    if (teamSlot + 1 >= amtLimit)
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(0, !assembly, allowAssembly));
+                    else
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot + 1, assembly, allowAssembly));
+                }
+                else
+                    MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu((teamSlot + 1) % DataManager.Instance.Save.ActiveTeam.Players.Count, false, allowAssembly));
+            }
+
+            else
+                base.UpdateKeys(input);
+        }
+    
+        protected override void SetPage(int page)
+        {
+            int totalOtherMemberPages = 3;
+            CurrentPage = page;
+            if (TotalChoices.Length == 1 && !ShowPagesOnSingle)
+                PageText.SetText("");
+            else
+                PageText.SetText("(" + (CurrentPage + 1 + totalOtherMemberPages) + "/" + (TotalChoices.Length + totalOtherMemberPages) + ")");
+            IChoosable[] choices = new IChoosable[TotalChoices[CurrentPage].Length];
+            for (int ii = 0; ii < choices.Length; ii++)
+                choices[ii] = TotalChoices[CurrentPage][ii];
+            SetChoices(choices);
+            CurrentChoice = Math.Min(CurrentChoice, choices.Length - 1);
+        }
+        
+        public override void Draw(SpriteBatch spriteBatch)
+        {
+            if (!Visible)
+                return;
+            base.Draw(spriteBatch);
+
+            //draw other windows
+            summaryMenu.Draw(spriteBatch);
+        }
+    }
+}

--- a/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
+++ b/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
@@ -20,7 +20,7 @@ namespace RogueEssence.Menu
 
         SkillSummary summaryMenu;
 
-        public MemberLearnsetMenu(int teamSlot, bool assembly, bool allowAssembly)
+        public MemberLearnsetMenu(int teamSlot, bool assembly, bool allowAssembly, bool maxPage)
         {
             this.teamSlot = teamSlot;
             this.assembly = assembly;
@@ -40,7 +40,7 @@ namespace RogueEssence.Menu
                 SkillData skillEntry = DataManager.Instance.GetSkill(levelUpSkill.Skill);
 
                 MenuText skillText = new MenuText(skillEntry.GetIconName(), new Loc(1, 1), Color.White);
-                MenuText levelUpText = new MenuText(levelUpSkill.Level.ToString(),
+                MenuText levelUpText = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", levelUpSkill.Level),
                     new Loc(GraphicsManager.ScreenWidth - 72, 1), DirV.Up, DirH.Right, Color.White);
 
                 Skills.Add(skill);
@@ -54,59 +54,55 @@ namespace RogueEssence.Menu
                     VERT_SPACE * 4),
                 new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8)));
 
-            Initialize(new Loc(16, 16), GraphicsManager.ScreenWidth - 32, "", choices, 0, 0, SLOTS_PER_PAGE);
+            Initialize(new Loc(16, 16), GraphicsManager.ScreenWidth - 32, "", choices, 0, maxPage ? (choices.Length - 1) : 0, SLOTS_PER_PAGE);
         }
 
         protected override void ChoiceChanged()
         {
-            Title.SetText(Text.FormatKey("MENU_TEAM_LEARNSET",
-                DataManager.Instance.Save.ActiveTeam.Players[teamSlot].GetDisplayName(true)));
+            Title.SetText(Text.FormatKey("MENU_TEAM_LEARNSET"));
             summaryMenu.SetSkill(Skills[CurrentChoiceTotal]);
             base.ChoiceChanged();
         }
         
         protected override void UpdateKeys(InputManager input)
         {
-            if (CurrentPage - 1 == -1 && IsInputting(input, Dir8.Left))
+            if (CurrentPage - 1 < 0 && IsInputting(input, Dir8.Left))
             {
                 GameManager.Instance.SE("Menu/Skip");
                 MenuManager.Instance.ReplaceMenu(new MemberInfoMenu(teamSlot, assembly, allowAssembly));
             }
-
-            else if (CurrentPage + 1 == TotalChoices.Length && IsInputting(input, Dir8.Right))
+            else if (CurrentPage + 1 >= TotalChoices.Length && IsInputting(input, Dir8.Right))
             {
                 GameManager.Instance.SE("Menu/Skip");
                 MenuManager.Instance.ReplaceMenu(new MemberFeaturesMenu(teamSlot, assembly, allowAssembly));
             }
-            
-            else if (CurrentChoice - 1 == -1 && IsInputting(input, Dir8.Up))
+            else if (CurrentChoice - 1 < 0 && IsInputting(input, Dir8.Up))
             {
                 GameManager.Instance.SE("Menu/Skip");
                 if (allowAssembly)
                 {
                     int amtLimit = (!assembly) ? DataManager.Instance.Save.ActiveTeam.Assembly.Count : DataManager.Instance.Save.ActiveTeam.Players.Count;
                     if (teamSlot - 1 < 0)
-                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(amtLimit - 1, !assembly, allowAssembly));
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(amtLimit - 1, !assembly, allowAssembly, false));
                     else
-                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot - 1, assembly, allowAssembly));
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot - 1, assembly, allowAssembly, false));
                 }
                 else
-                    MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu((teamSlot + DataManager.Instance.Save.ActiveTeam.Players.Count - 1) % DataManager.Instance.Save.ActiveTeam.Players.Count, false, allowAssembly));
+                    MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu((teamSlot + DataManager.Instance.Save.ActiveTeam.Players.Count - 1) % DataManager.Instance.Save.ActiveTeam.Players.Count, false, allowAssembly, false));
             }
-        
-            else if (CurrentChoice + 1 == SLOTS_PER_PAGE && IsInputting(input, Dir8.Down))
+            else if (CurrentChoice + 1 >= SLOTS_PER_PAGE && IsInputting(input, Dir8.Down))
             {
                 GameManager.Instance.SE("Menu/Skip");
                 if (allowAssembly)
                 {
                     int amtLimit = assembly ? DataManager.Instance.Save.ActiveTeam.Assembly.Count : DataManager.Instance.Save.ActiveTeam.Players.Count;
                     if (teamSlot + 1 >= amtLimit)
-                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(0, !assembly, allowAssembly));
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(0, !assembly, allowAssembly, false));
                     else
-                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot + 1, assembly, allowAssembly));
+                        MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu(teamSlot + 1, assembly, allowAssembly, false));
                 }
                 else
-                    MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu((teamSlot + 1) % DataManager.Instance.Save.ActiveTeam.Players.Count, false, allowAssembly));
+                    MenuManager.Instance.ReplaceMenu(new MemberLearnsetMenu((teamSlot + 1) % DataManager.Instance.Save.ActiveTeam.Players.Count, false, allowAssembly, false));
             }
 
             else

--- a/RogueEssence/Menu/Team/MemberStatsMenu.cs
+++ b/RogueEssence/Menu/Team/MemberStatsMenu.cs
@@ -13,6 +13,7 @@ namespace RogueEssence.Menu
         int teamSlot;
         bool assembly;
         bool allowAssembly;
+        
         public MenuText Title;
         public MenuDivider Div;
 
@@ -57,9 +58,16 @@ namespace RogueEssence.Menu
             this.allowAssembly = allowAssembly;
 
             Character player = assembly ? DataManager.Instance.Save.ActiveTeam.Assembly[teamSlot] : DataManager.Instance.Save.ActiveTeam.Players[teamSlot];
-
+            
+            MonsterData dexEntry = DataManager.Instance.GetMonster(player.BaseForm.Species);
+            BaseMonsterForm formEntry = dexEntry.Forms[player.BaseForm.Form];
+            
+            int totalLearnsetPages = (int) Math.Ceiling((double) formEntry.LevelSkills.Count / MemberLearnsetMenu.SLOTS_PER_PAGE);
+            int totalOtherMemberPages = 3;
+            int totalPages = totalLearnsetPages + totalOtherMemberPages;
+            
             //TODO: align the page text properly
-            Title = new MenuText(Text.FormatKey("MENU_STATS_TITLE") +" (2/3)", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
+            Title = new MenuText(Text.FormatKey("MENU_STATS_TITLE") + $" (2/{totalPages})", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
             Div = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + LINE_HEIGHT), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
 
 


### PR DESCRIPTION
This PR adds the multipage Learnset menu to the team member menus

It slightly modifies the other the team member menus by changing the hardcoded total page numbers in each menu and where each menu navigates to with the addition of the Learnset menu

Things that can be improved:

(redundancy) Calculate the total page number in the first menu only, instead of calculating it all the menus and pass in the page number to each other menu?


<img width="636" height="478" alt="Screenshot 2026-01-10 at 2 14 56 PM" src="https://github.com/user-attachments/assets/74dbb773-3361-4483-a09c-4b6129f41264" />
