### PR TITLE
Add move preview

### DIFF
--- a/RogueEssence/Dungeon/Characters/CharAction.cs
+++ b/RogueEssence/Dungeon/Characters/CharAction.cs
@@ -1300,6 +1300,13 @@ namespace RogueEssence.Dungeon
             }
 
             //if impossible to find, use the default farthest landing spot
+            Loc targetLoc = GetFarthestLanding(owner, ownerLoc, dir, mod);
+            return targetLoc;
+        }
+        
+        public Loc GetFarthestLanding(Character owner, Loc ownerLoc, Dir8 dir, int mod)
+        {
+            int modRange = GetModRange(mod);
             Loc targetLoc = ownerLoc;
             Loc addLoc = dir.GetLoc();
             for (int ii = 0; ii < modRange; ii++)

--- a/RogueEssence/Dungeon/DSceneMap.cs
+++ b/RogueEssence/Dungeon/DSceneMap.cs
@@ -1475,7 +1475,7 @@ namespace RogueEssence.Dungeon
             }
             return false;
         }
-
+        
         public bool CanTeamSeeLoc(Team team, Loc loc)
         {
             foreach (Character player in team.Players)
@@ -1488,6 +1488,19 @@ namespace RogueEssence.Dungeon
             }
             return false;
         }
+        public bool CanTeamSeeCharLoc(Team team, Loc loc)
+        {
+            foreach (Character player in team.Players)
+            {
+                if (!player.Dead)
+                {
+                    if (player.CanSeeLoc(loc, player.GetCharSight()))
+                        return true;
+                }
+            }
+            return false;
+        }
+
 
         public bool ShotBlocked(Character character, Loc loc, Dir8 dir, Alignment blockedAlignments, bool useMobility, bool blockedByWall)
         {

--- a/RogueEssence/Menu/Skills/SkillChosenMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillChosenMenu.cs
@@ -33,6 +33,12 @@ namespace RogueEssence.Menu
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SKILL_SWITCH"), switchAction));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SHIFT_UP"), () => { shiftPosition(false); }, shiftUp, shiftUp ? Color.White : Color.Red));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SHIFT_DOWN"), () => { shiftPosition(true); }, shiftDown, shiftDown ? Color.White : Color.Red));
+            if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
+            {
+                CharIndex turnChar = ZoneManager.Instance.CurrentMap.CurrentTurnMap.GetCurrentTurnChar();
+                if (turnChar.Faction == Faction.Player && turnChar.Char == teamIndex)
+                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SKILL_PREVIEW"), previewMove));
+            }
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
 
             int choice_width = CalculateChoiceLength(choices, 72);
@@ -64,6 +70,17 @@ namespace RogueEssence.Menu
                 newSlot += 2;
             }
             MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, teamIndex, swapSlot), teamIndex, newSlot);
+        }
+
+        private void previewMove()
+        {
+            MenuManager.Instance.ClearMenus();
+            if (skillSlot != DungeonScene.Instance.CurrentPreviewMove )
+            {
+                DungeonScene.Instance.CurrentPreviewMove = skillSlot;
+                DungeonScene.Instance.CalculateMovePreviews();
+            }
+
         }
     }
 }

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -1299,7 +1299,6 @@ namespace RogueEssence
 
             if (totalErrorCount > 0)
                 GraphicsManager.SysFont.DrawText(spriteBatch, GraphicsManager.ScreenWidth - 2, GraphicsManager.ScreenHeight - 2, String.Format("{0} ERRORS", totalErrorCount), null, DirV.Down, DirH.Right, Color.Red);
-
             if (ShowDebug)
             {
                 spriteBatch.End();


### PR DESCRIPTION
This PR adds the "Preview" option to move menu to view the range of the move. The range of the move can also be accessed through the hotkeys A+Delete+SkillButton

Once the move is in "Preview" mode, the player can view the range of the move without having to hold the hotkeys, and can press the regular attack button to use the previewed move 

TODO: Calculate the value for rangeMod (currently defaulted to 0)

<img width="640" height="479" alt="Screenshot 2026-01-10 at 1 33 18 PM" src="https://github.com/user-attachments/assets/cb19ded3-0b68-44be-9206-71523e31e047" />