### PR TITLE
fix move preview + slight logic tweak

### DIFF
--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -917,10 +917,13 @@ namespace RogueEssence.Dungeon
                 HashSet<Loc> hitTiles = new HashSet<Loc>();
                 foreach (Loc loc in data.HitboxAction.GetPreTargets(FocusedCharacter, dir, rangeMod))
                 {
-                    if (!canViewPastWalls && CanTeamSeeCharLoc(ActiveTeam, loc))
+                    if (!canViewPastWalls)
                     {
-                        foreach (Loc expLoc in explosion.IterateTargetedTiles(loc))
+                        if (CanTeamSeeCharLoc(ActiveTeam, loc))
+                        {
+                            foreach (Loc expLoc in explosion.IterateTargetedTiles(loc))
                                 hitTiles.Add(ZoneManager.Instance.CurrentMap.WrapLoc(expLoc));
+                        }
                     }
                     else
                     {
@@ -928,12 +931,14 @@ namespace RogueEssence.Dungeon
                         if (hitbox is ThrowAction)
                         {
                             ThrowAction throwAction = hitbox as ThrowAction;
-                            //use the farthest distance of throw action if the team cannot see the enemy
-                            Loc furthestLoc = throwAction.GetFarthestLanding(FocusedCharacter, FocusedCharacter.CharLoc, dir, rangeMod);
-                            if (furthestLoc != loc)
+                            if (!CanTeamSeeCharLoc(ActiveTeam, currLoc))
                             {
-                                if (!CanTeamSeeCharLoc(ActiveTeam, currLoc))
-                                    currLoc = furthestLoc;
+                                //use the farthest distance of throw action if the team cannot see the enemy
+                                Loc furthestLoc = throwAction.GetFarthestLanding(FocusedCharacter, FocusedCharacter.CharLoc, dir, rangeMod);
+                                if (furthestLoc != loc)
+                                {
+                                    currLoc = furthestLoc;   
+                                }
                             }
                         }
                         foreach (Loc expLoc in explosion.IterateTargetedTiles(currLoc))

--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -934,11 +934,7 @@ namespace RogueEssence.Dungeon
                             if (!CanTeamSeeCharLoc(ActiveTeam, currLoc))
                             {
                                 //use the farthest distance of throw action if the team cannot see the enemy
-                                Loc furthestLoc = throwAction.GetFarthestLanding(FocusedCharacter, FocusedCharacter.CharLoc, dir, rangeMod);
-                                if (furthestLoc != loc)
-                                {
-                                    currLoc = furthestLoc;   
-                                }
+                                currLoc = throwAction.GetFarthestLanding(FocusedCharacter, FocusedCharacter.CharLoc, dir, rangeMod);
                             }
                         }
                         foreach (Loc expLoc in explosion.IterateTargetedTiles(currLoc))


### PR DESCRIPTION
This PR fixes an issue where area moves like Draco Meteor reveal the location of the enemy in the darkness. This is fixed by moving the `CanTeamSeeCharLoc(ActiveTeam, loc)` if statement down a level to ensure that the hit tiles aren't added in the else statement.
