### PR TITLE
remove check in TitleDialog

### DIFF
--- a/RogueEssence/Menu/Dialogue/TitleDialog.cs
+++ b/RogueEssence/Menu/Dialogue/TitleDialog.cs
@@ -206,8 +206,7 @@ namespace RogueEssence.Menu
             else
             {
                 TotalTextTime += elapsedTime;
-                if (!CurrentText.Finished)
-                    CurrentTextTime += elapsedTime;
+                CurrentTextTime += elapsedTime;
                 if (scrolling)
                     CurrentScrollTime += elapsedTime;
             }


### PR DESCRIPTION
Currently, using a positive integer in the second parameter in WaitShowVoiceOver (such as `UI:WaitShowVoiceOver("testing", 20)`) causes the text to display indefinitely.

This PR removes a check to fix this. 
