### PR TITLE
Add restart run at end of failed roguelocke run

### DIFF
--- a/RogueEssence/Data/GameProgress.cs
+++ b/RogueEssence/Data/GameProgress.cs
@@ -1199,7 +1199,7 @@ namespace RogueEssence.Data
                 yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(question));
                 yield return new WaitForFrames(20);
                 if (restart)
-                    restartRun();
+                    restartRun(this.config);
                 else
                     GameManager.Instance.SceneOutcome = GameManager.Instance.RestartToTitle();
             }
@@ -1304,14 +1304,14 @@ namespace RogueEssence.Data
             }
         }
 
-        private void restartRun()
+        private static void restartRun(RogueConfig oldConfig)
         {
+            RogueConfig config = new RogueConfig(oldConfig);
             if (config.TeamRandomized)
                 config.TeamName = DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)];
+
             if (config.SeedRandomized)
-            {
                 config.Seed = MathUtils.Rand.NextUInt64();
-            }
 
             if (config.StarterRandomized)
             {
@@ -1327,10 +1327,10 @@ namespace RogueEssence.Data
                 List<string> destinations = RogueDestMenu.GetDestinationsList();
                 config.Destination = destinations[MathUtils.Rand.Next(destinations.Count)];
             }
-            GameManager.Instance.SceneOutcome = StartRogue();
+            GameManager.Instance.SceneOutcome = StartRogue(config);
 
         }
-        public IEnumerator<YieldInstruction> StartRogue()
+        public static IEnumerator<YieldInstruction> StartRogue(RogueConfig config)
         {
             GameManager.Instance.BGM("", true);
             yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.FadeOut(false));
@@ -1384,8 +1384,6 @@ namespace RogueEssence.Data
                 DiagManager.Instance.LogError(ex);
             }
             
-            // TODO - calling this resolves the replay error, but causes one other error
-            ZoneManager.InitInstance();
             yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.BeginGameInSegment(new ZoneLoc(config.Destination, new SegLoc()), GameProgress.DungeonStakes.Risk, true, false));
         }
     }
@@ -1405,5 +1403,26 @@ namespace RogueEssence.Data
         public bool SeedRandomized;
         public string SkinSetting;
         public string Nickname;
+
+        public RogueConfig()
+        {
+        }
+
+        public RogueConfig(RogueConfig other)
+        {
+            Destination = other.Destination;
+            DestinationRandomized = other.DestinationRandomized;
+            TeamName = other.TeamName;
+            TeamRandomized = other.TeamRandomized;
+            Starter = other.Starter;
+            StarterRandomized = other.StarterRandomized;
+            IntrinsicSetting = other.IntrinsicSetting;
+            FormSetting = other.FormSetting;
+            GenderSetting = other.GenderSetting;
+            Seed = other.Seed;
+            SeedRandomized = other.SeedRandomized;
+            SkinSetting = other.SkinSetting;
+            Nickname = other.Nickname;
+        }
     }
 }

--- a/RogueEssence/Data/GameProgress.cs
+++ b/RogueEssence/Data/GameProgress.cs
@@ -1199,7 +1199,7 @@ namespace RogueEssence.Data
                 yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(question));
                 yield return new WaitForFrames(20);
                 if (restart)
-                    restartRun(this.config);
+                    GameManager.Instance.SceneOutcome = GameManager.Instance.RestartToRogue(RogueConfig.RerollFromOther(this.config));
                 else
                     GameManager.Instance.SceneOutcome = GameManager.Instance.RestartToTitle();
             }
@@ -1304,32 +1304,6 @@ namespace RogueEssence.Data
             }
         }
 
-        private static void restartRun(RogueConfig oldConfig)
-        {
-            RogueConfig config = new RogueConfig(oldConfig);
-            if (config.TeamRandomized)
-                config.TeamName = DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)];
-
-            if (config.SeedRandomized)
-                config.Seed = MathUtils.Rand.NextUInt64();
-
-            if (config.StarterRandomized)
-            {
-                List<string> starters = CharaChoiceMenu.GetStartersList();
-                string starter = starters[MathUtils.Rand.Next(starters.Count)];
-                config.Starter = starter;
-                config.IntrinsicSetting = -1;
-                config.FormSetting = -1;
-                config.GenderSetting = Gender.Unknown;
-            }
-            if (config.DestinationRandomized)
-            {
-                List<string> destinations = RogueDestMenu.GetDestinationsList();
-                config.Destination = destinations[MathUtils.Rand.Next(destinations.Count)];
-            }
-            GameManager.Instance.SceneOutcome = StartRogue(config);
-
-        }
         public static IEnumerator<YieldInstruction> StartRogue(RogueConfig config)
         {
             GameManager.Instance.BGM("", true);
@@ -1423,6 +1397,32 @@ namespace RogueEssence.Data
             SeedRandomized = other.SeedRandomized;
             SkinSetting = other.SkinSetting;
             Nickname = other.Nickname;
+        }
+
+        public static RogueConfig RerollFromOther(RogueConfig oldConfig)
+        {
+            RogueConfig config = new RogueConfig(oldConfig);
+            if (config.TeamRandomized)
+                config.TeamName = DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)];
+
+            if (config.SeedRandomized)
+                config.Seed = MathUtils.Rand.NextUInt64();
+
+            if (config.StarterRandomized)
+            {
+                List<string> starters = CharaChoiceMenu.GetStartersList();
+                string starter = starters[MathUtils.Rand.Next(starters.Count)];
+                config.Starter = starter;
+                config.IntrinsicSetting = -1;
+                config.FormSetting = -1;
+                config.GenderSetting = Gender.Unknown;
+            }
+            if (config.DestinationRandomized)
+            {
+                List<string> destinations = RogueDestMenu.GetDestinationsList();
+                config.Destination = destinations[MathUtils.Rand.Next(destinations.Count)];
+            }
+            return config;
         }
     }
 }

--- a/RogueEssence/Menu/Records/ReplayChosenMenu.cs
+++ b/RogueEssence/Menu/Records/ReplayChosenMenu.cs
@@ -157,7 +157,7 @@ namespace RogueEssence.Menu
                     if (verifying)
                         DataManager.Instance.Loading = DataManager.LoadMode.Verifying;
                     DataManager.Instance.CurrentReplay = replay;
-                    yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.Save.NextDest));
+                    yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.Save.NextDest, true, false));
                     yield break;
                 }
             }

--- a/RogueEssence/Menu/Rescue/RescueMenu.cs
+++ b/RogueEssence/Menu/Rescue/RescueMenu.cs
@@ -220,7 +220,7 @@ namespace RogueEssence.Menu
             DataManager.Instance.CurrentReplay = replay;
 
             yield return CoroutineManager.Instance.StartCoroutine(ZoneManager.Instance.CurrentZone.OnInit());
-            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.Save.NextDest));
+            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.Save.NextDest, true, false));
         }
 
         private void completeAOK()

--- a/RogueEssence/Menu/Rogue/CharaChoiceMenu.cs
+++ b/RogueEssence/Menu/Rogue/CharaChoiceMenu.cs
@@ -181,7 +181,6 @@ namespace RogueEssence.Menu
         
         public IEnumerator<YieldInstruction> Begin(int choice, string name)
         {
-            RogueProgress save = new RogueProgress(Guid.NewGuid().ToString().ToUpper(), config);
             string starter = startChars[choice];
             config.IntrinsicSetting = IntrinsicSetting;
             config.FormSetting = FormSetting;
@@ -190,7 +189,7 @@ namespace RogueEssence.Menu
             config.Nickname = name;
             config.Starter = starter;
             
-            return save.StartRogue();
+            return RogueProgress.StartRogue(config);
         }
 
         public static List<string> GetStartersList()

--- a/RogueEssence/Menu/Rogue/RogueDestMenu.cs
+++ b/RogueEssence/Menu/Rogue/RogueDestMenu.cs
@@ -21,30 +21,15 @@ namespace RogueEssence.Menu
 
         public RogueDestMenu()
         {
-            dungeonIndices = new List<string>();
-
-            foreach(string key in DataManager.Instance.DataIndices[DataManager.DataType.Zone].GetOrderedKeys(true))
-            {
-                ZoneEntrySummary summary = DataManager.Instance.DataIndices[DataManager.DataType.Zone].Get(key) as ZoneEntrySummary;
-                if (!DiagManager.Instance.DevMode)
-                {
-                    if (DataManager.Instance.Save.GetDungeonUnlock(key) == GameProgress.UnlockState.None)
-                        continue;
-                    if (summary == null)
-                        continue;
-                    if (summary.Rogue != RogueStatus.AllTransfer)
-                        continue;
-                }
-                dungeonIndices.Add(key);
-            }
+            dungeonIndices = GetDestinationsList();
 
             List<MenuChoice> flatChoices = new List<MenuChoice>();
-            flatChoices.Add(new MenuTextChoice(Text.FormatKey("MENU_START_RANDOM"), () => { choose(dungeonIndices[MathUtils.Rand.Next(dungeonIndices.Count)]); }));
+            flatChoices.Add(new MenuTextChoice(Text.FormatKey("MENU_START_RANDOM"), () => { choose(dungeonIndices[MathUtils.Rand.Next(dungeonIndices.Count)], true); }));
             for (int ii = 0; ii < dungeonIndices.Count; ii++)
             {
                 string zone = dungeonIndices[ii];
                 ZoneEntrySummary summary = DataManager.Instance.DataIndices[DataManager.DataType.Zone].Get(zone) as ZoneEntrySummary;
-                flatChoices.Add(new MenuTextChoice(summary.GetColoredName(), () => { choose(zone); }));
+                flatChoices.Add(new MenuTextChoice(summary.GetColoredName(), () => { choose(zone, false); }));
             }
 
             int actualChoice = Math.Min(Math.Max(0, defaultChoice), flatChoices.Count - 1);
@@ -94,8 +79,9 @@ namespace RogueEssence.Menu
             infoMenu.Draw(spriteBatch);
         }
 
-        private void choose(string choice)
+        private void choose(string choice, bool randomized)
         {
+            GameManager.Instance.RogueConfig.DestinationRandomized = randomized;
             MenuManager.Instance.AddMenu(new RogueTeamInputMenu(choice, seed), false);
         }
 
@@ -124,6 +110,28 @@ namespace RogueEssence.Menu
                 seed = null;
 
             infoMenu.SetDetails(seed);
+        }
+
+        public static List<string> GetDestinationsList()
+        {
+            List<string> dungeonIndices = new List<string>();
+
+            foreach(string key in DataManager.Instance.DataIndices[DataManager.DataType.Zone].GetOrderedKeys(true))
+            {
+                ZoneEntrySummary summary = DataManager.Instance.DataIndices[DataManager.DataType.Zone].Get(key) as ZoneEntrySummary;
+                if (!DiagManager.Instance.DevMode)
+                {
+                    if (DataManager.Instance.Save.GetDungeonUnlock(key) == GameProgress.UnlockState.None)
+                        continue;
+                    if (summary == null)
+                        continue;
+                    if (summary.Rogue != RogueStatus.AllTransfer)
+                        continue;
+                }
+                dungeonIndices.Add(key); 
+            }
+
+            return dungeonIndices;
         }
     }
 }

--- a/RogueEssence/Menu/Rogue/RogueDestMenu.cs
+++ b/RogueEssence/Menu/Rogue/RogueDestMenu.cs
@@ -81,8 +81,14 @@ namespace RogueEssence.Menu
 
         private void choose(string choice, bool randomized)
         {
-            GameManager.Instance.RogueConfig.DestinationRandomized = randomized;
-            MenuManager.Instance.AddMenu(new RogueTeamInputMenu(choice, seed), false);
+            RogueConfig config = new RogueConfig();
+            config.Destination = choice;
+            config.DestinationRandomized = randomized;
+            bool seedRandomized = !seed.HasValue;
+            ulong seedVal = seedRandomized ?  MathUtils.Rand.NextUInt64() : seed.Value;
+            config.Seed = seedVal;
+            config.SeedRandomized = seedRandomized;
+            MenuManager.Instance.AddMenu(new RogueTeamInputMenu(config), false);
         }
 
 

--- a/RogueEssence/Menu/Rogue/RogueTeamInputMenu.cs
+++ b/RogueEssence/Menu/Rogue/RogueTeamInputMenu.cs
@@ -51,7 +51,8 @@ namespace RogueEssence.Menu
                 Text.SetText(DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)]);
                 UpdatePickerPos();
             }
-            MenuManager.Instance.AddMenu(new CharaChoiceMenu(Text.Text, randomized, chosenDest, seed), false);
+            GameManager.Instance.RogueConfig.TeamRandomized = randomized;
+            MenuManager.Instance.AddMenu(new CharaChoiceMenu(Text.Text, chosenDest, seed), false);
         }
     }
 }

--- a/RogueEssence/Menu/Rogue/RogueTeamInputMenu.cs
+++ b/RogueEssence/Menu/Rogue/RogueTeamInputMenu.cs
@@ -7,15 +7,12 @@ namespace RogueEssence.Menu
     public class RogueTeamInputMenu : TextInputMenu
     {
         public override int MaxLength { get { return 96; } }
-
+        private RogueConfig config;
         private bool randomized;
-        private string chosenDest;
-        private ulong? seed;
 
-        public RogueTeamInputMenu(string chosenDungeon, ulong? seed)
+        public RogueTeamInputMenu(RogueConfig config)
         {
-            chosenDest = chosenDungeon;
-            this.seed = seed;
+            this.config = config;
             Initialize(RogueEssence.Text.FormatKey("INPUT_TEAM_TITLE"), RogueEssence.Text.FormatKey("INPUT_TEAM_DESC"), 256);
         }
 
@@ -51,8 +48,10 @@ namespace RogueEssence.Menu
                 Text.SetText(DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)]);
                 UpdatePickerPos();
             }
-            GameManager.Instance.RogueConfig.TeamRandomized = randomized;
-            MenuManager.Instance.AddMenu(new CharaChoiceMenu(Text.Text, chosenDest, seed), false);
+
+            config.TeamName = Text.Text;
+            config.TeamRandomized = randomized;
+            MenuManager.Instance.AddMenu(new CharaChoiceMenu(config), false);
         }
     }
 }

--- a/RogueEssence/Menu/Rogue/RogueTeamInputMenu.cs
+++ b/RogueEssence/Menu/Rogue/RogueTeamInputMenu.cs
@@ -8,6 +8,7 @@ namespace RogueEssence.Menu
     {
         public override int MaxLength { get { return 96; } }
 
+        private bool randomized;
         private string chosenDest;
         private ulong? seed;
 
@@ -22,6 +23,7 @@ namespace RogueEssence.Menu
         {
             if (input.BaseKeyPressed(Keys.Tab))
             {
+                randomized = true;
                 //tab will replace the current line with a suggestion
                 GameManager.Instance.SE("Menu/Skip");
                 Text.SetText(DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)]);
@@ -29,7 +31,15 @@ namespace RogueEssence.Menu
                 UpdatePickerPos();
             }
             else
-                base.Update(input);
+            {
+                string prevText = Text.Text;
+                base.Update(input); 
+                if (prevText != Text.Text)
+                {
+                    randomized = false;
+                }
+            }
+
         }
 
         protected override void Confirmed()
@@ -37,10 +47,11 @@ namespace RogueEssence.Menu
             GameManager.Instance.SE("Menu/Confirm");
             if (Text.Text == "")
             {
+                randomized = true;
                 Text.SetText(DataManager.Instance.StartTeams[MathUtils.Rand.Next(DataManager.Instance.StartTeams.Count)]);
                 UpdatePickerPos();
             }
-            MenuManager.Instance.AddMenu(new CharaChoiceMenu(Text.Text, chosenDest, seed), false);
+            MenuManager.Instance.AddMenu(new CharaChoiceMenu(Text.Text, randomized, chosenDest, seed), false);
         }
     }
 }

--- a/RogueEssence/Menu/Top/TopMenu.cs
+++ b/RogueEssence/Menu/Top/TopMenu.cs
@@ -398,7 +398,7 @@ namespace RogueEssence.Menu
                 DiagManager.Instance.LogError(ex);
             }
 
-            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.StartMap));
+            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.StartMap, true, false));
         }
 
         private static IEnumerator<YieldInstruction> DefaultBegin()
@@ -407,7 +407,7 @@ namespace RogueEssence.Menu
 
             GameManager.Instance.NewGamePlus(MathUtils.Rand.NextUInt64());
 
-            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.StartMap));
+            yield return CoroutineManager.Instance.StartCoroutine(GameManager.Instance.MoveToZone(DataManager.Instance.StartMap, true, false));
         }
 
     }

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -88,7 +88,7 @@ namespace RogueEssence
         public const int FANFARE_FADE_START = 3;
         public const int FANFARE_FADE_END = 40;
         public const int FANFARE_WAIT_EXTRA = 20;
-
+        public RogueStartConfig rogueConfig;
 
         public GameManager()
         {
@@ -1397,6 +1397,22 @@ namespace RogueEssence
                 DungeonScene.Instance.LogMsg(msg);
                 yield return new WaitForFrames(GameManager.Instance.ModifyBattleSpeed(30));
             }
+        }
+
+        public class RogueStartConfig
+        {
+            public int IntrinsicSetting;
+            public int FormSetting;
+            public Gender GenderSetting;
+            public string TeamName;
+            public bool TeamRandomized;
+            public ulong Seed;
+            public bool Seeded;
+            public string SkinSetting;
+            public string Nickname;
+            public string Species;
+            public string Destination;
+            public RogueStartConfig() {}
         }
     }
 }

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -88,8 +88,6 @@ namespace RogueEssence
         public const int FANFARE_FADE_START = 3;
         public const int FANFARE_FADE_END = 40;
         public const int FANFARE_WAIT_EXTRA = 20;
-        public RogueStartConfig RogueConfig;
-
         public GameManager()
         {
             fadedTitle = "";
@@ -99,7 +97,6 @@ namespace RogueEssence
             InputManager = new InputManager();
 
             LoopingSE = new Dictionary<string, (float volume, float diff)>();
-            RogueConfig = new RogueStartConfig();
 
             DiagManager.Instance.SetErrorListener(OnError, ErrorTrace);
 
@@ -1398,24 +1395,6 @@ namespace RogueEssence
                 DungeonScene.Instance.LogMsg(msg);
                 yield return new WaitForFrames(GameManager.Instance.ModifyBattleSpeed(30));
             }
-        }
-
-        public class RogueStartConfig
-        {
-            public int IntrinsicSetting;
-            public int FormSetting;
-            public Gender GenderSetting;
-            public string TeamName;
-            public bool TeamRandomized;
-            public ulong Seed;
-            public bool Seeded;
-            public string SkinSetting;
-            public string Nickname;
-            public string Starter;
-            public bool StarterRandomized;
-            
-            public string Destination;
-            public bool DestinationRandomized;
         }
     }
 }

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -942,6 +942,13 @@ namespace RogueEssence
             yield break;
         }
 
+        public IEnumerator<YieldInstruction> RestartToRogue(RogueConfig config)
+        {
+            cleanup();
+            reInit();
+            yield return CoroutineManager.Instance.StartCoroutine(RogueProgress.StartRogue(config));
+        }
+
         public void MoveToScene(BaseScene scene)
         {
             //need to transfer player data

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -88,6 +88,8 @@ namespace RogueEssence
         public const int FANFARE_FADE_START = 3;
         public const int FANFARE_FADE_END = 40;
         public const int FANFARE_WAIT_EXTRA = 20;
+
+
         public GameManager()
         {
             fadedTitle = "";

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -88,7 +88,7 @@ namespace RogueEssence
         public const int FANFARE_FADE_START = 3;
         public const int FANFARE_FADE_END = 40;
         public const int FANFARE_WAIT_EXTRA = 20;
-        public RogueStartConfig rogueConfig;
+        public RogueStartConfig RogueConfig;
 
         public GameManager()
         {
@@ -99,6 +99,7 @@ namespace RogueEssence
             InputManager = new InputManager();
 
             LoopingSE = new Dictionary<string, (float volume, float diff)>();
+            RogueConfig = new RogueStartConfig();
 
             DiagManager.Instance.SetErrorListener(OnError, ErrorTrace);
 
@@ -1410,9 +1411,11 @@ namespace RogueEssence
             public bool Seeded;
             public string SkinSetting;
             public string Nickname;
-            public string Species;
+            public string Starter;
+            public bool StarterRandomized;
+            
             public string Destination;
-            public RogueStartConfig() {}
+            public bool DestinationRandomized;
         }
     }
 }


### PR DESCRIPTION
**WIP**
Currently how this PR's restart functionality works is that if the player chooses a random starter, then the restart will also choose a random starter, unless the player specifies. This applies to the Intrinsic, Destination, Gender, etc. 

The Roguelocke menu's also now pass a RogueConfig to each other to store the current configuration for restarting.

Current Issues:
- Replays don't work correctly for unseeded runs after the first replay. 
I've added at  `ZoneManager.InitInstance();` as a "workaround" on line 1388 which should be probably be replaced with a fix since it does cause an error
For a little bit more info, check [here](https://discord.com/channels/534207185333256223/566027008312606734/1064041427622961194)