### PR TITLE
Fix timer + border settings

### DIFF
--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -14,9 +14,9 @@ namespace RogueEssence.Menu
     {
         private static int defaultChoice;
 
-        private int timerStart;
         private bool inReplay;
-        
+
+        MenuText menuTimer;
         SummaryMenu titleMenu;
         SummaryMenu summaryMenu;
         public MainMenu()
@@ -122,7 +122,14 @@ namespace RogueEssence.Menu
                 summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HUNGER", character.Fullness, character.MaxFullness),
                 new Loc(text_start + hunger_length / 2, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
             }
-            timerStart = GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + level_length + hp_length + remaining_width + hunger_length / 2;
+            
+            if (GameManager.Instance.CurrentScene == DungeonScene.Instance && !inReplay)
+            {
+                int timerStart = GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + level_length + hp_length + remaining_width + hunger_length / 2;
+                menuTimer = new MenuText(Text.FormatKey("MENU_TIMER", DataManager.Instance.Save.GetDungeonTimeDisplay()),
+                    new Loc(timerStart, GraphicsManager.MenuBG.TileHeight), DirH.None);
+                summaryMenu.Elements.Add(menuTimer);
+            }
         }
 
         private void checkGround()
@@ -169,12 +176,7 @@ namespace RogueEssence.Menu
         public override void Update(InputManager input)
         {
             base.Update(input);
-            if (GameManager.Instance.CurrentScene == DungeonScene.Instance && !inReplay)
-            {
-                summaryMenu.Elements.RemoveAt(summaryMenu.Elements.Count - 1);
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TIMER", DataManager.Instance.Save.GetDungeonTimeDisplay()),
-                    new Loc(timerStart, GraphicsManager.MenuBG.TileHeight), DirH.None));
-            }
+            menuTimer?.SetText(Text.FormatKey("MENU_TIMER", DataManager.Instance.Save.GetDungeonTimeDisplay()));
         }
 
 

--- a/RogueEssence/Menu/Settings/SettingsMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsMenu.cs
@@ -130,7 +130,7 @@ namespace RogueEssence.Menu
                 SoundManager.BGMBalance = TotalChoices[index].CurrentChoice * 0.1f;
             else if (index == 1)
                 SoundManager.SEBalance = TotalChoices[index].CurrentChoice * 0.1f;
-            else if (index == 5)
+            else if (index == 6)
                 MenuBase.BorderStyle = TotalChoices[index].CurrentChoice;
 
             base.SettingChanged(index);


### PR DESCRIPTION
Currently, calling `summaryMenu.Elements.RemoveAt(summaryMenu.Elements.Count - 1);` removes the belly text of the last member when updating the timer.

This PR fixes this by setting the MenuText instead of removing the last menu element

Additionally border settings now uses the correct index
