### PR TITLE
main menu formatting + menutext splitting

### DIFF
--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -82,7 +82,13 @@ namespace RogueEssence.Menu
             summaryMenu = new SummaryMenu(Rect.FromPoints(new Loc(16, 32 + choices.Count * VERT_SPACE + GraphicsManager.MenuBG.TileHeight * 2),
                 new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8)));
             summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_BAG_MONEY", Text.FormatKey("MONEY_AMOUNT", DataManager.Instance.Save.ActiveTeam.Money)),
-                new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight)));
+                new Loc(GraphicsManager.MenuBG.TileWidth + 4, GraphicsManager.MenuBG.TileHeight)));
+            
+            int level_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_LEVEL_SHORT") + $"{DataManager.Instance.MaxLevel}");
+            int hp_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HP") + $" {999}/{999}");
+            int hunger_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HUNGER") + $" {Character.MAX_FULLNESS}/{Character.MAX_FULLNESS}");
+
+            int remaining_width = summaryMenu.Bounds.End.X - summaryMenu.Bounds.X - (GraphicsManager.MenuBG.TileWidth + 4) * 2 - level_length - hp_length - hunger_length - NicknameMenu.MAX_LENGTH;
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {
@@ -97,15 +103,14 @@ namespace RogueEssence.Menu
                     }
                 }
                 summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_MAP_CONDITION", weather),
-                    new Loc(summaryMenu.Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight)));
+                    new Loc(GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + remaining_width / 3, GraphicsManager.MenuBG.TileHeight), DirH.Left));
             }
-
-            int level_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", DataManager.Instance.MaxLevel));
-            int hp_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HP", 999, 999));
-            int hunger_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HUNGER", Character.MAX_FULLNESS, Character.MAX_FULLNESS));
-
-            int remaining_width = summaryMenu.Bounds.End.X - summaryMenu.Bounds.X - (GraphicsManager.MenuBG.TileWidth + 4) * 2 - level_length - hp_length - hunger_length - NicknameMenu.MAX_LENGTH;
-
+            
+            int max_hp_length = GraphicsManager.TextFont.SubstringWidth("999");
+            int max_fullness_length = GraphicsManager.TextFont.SubstringWidth(Character.MAX_FULLNESS.ToString());
+            int hp_label_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HP"));
+            int hunger_label_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HUNGER"));
+            
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
             {
                 Character character = DataManager.Instance.Save.ActiveTeam.Players[ii];
@@ -113,21 +118,42 @@ namespace RogueEssence.Menu
                 summaryMenu.Elements.Add(new MenuText(character.GetDisplayName(true),
                 new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT)));
                 text_start += NicknameMenu.MAX_LENGTH + remaining_width / 3;
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level),
-                new Loc(text_start + level_length / 2, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
-                text_start += level_length + remaining_width / 3;
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HP", character.HP, character.MaxHP),
-                new Loc(text_start + hp_length / 2, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
-                text_start += hp_length + remaining_width / 3;
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HUNGER", character.Fullness, character.MaxFullness),
-                new Loc(text_start + hunger_length / 2, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
+                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
+                text_start += level_length;
+                summaryMenu.Elements.Add(new MenuText(character.Level.ToString(),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Right));
+                text_start += remaining_width / 3;
+                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HP"),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
+                text_start += hp_label_length + max_hp_length + 4;
+                summaryMenu.Elements.Add(new MenuText(character.HP.ToString(),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Right));
+                text_start += 4;
+                summaryMenu.Elements.Add(new MenuText("/",
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
+                text_start += character.MaxHP.ToString().StartsWith("1") ? 2 : 4;
+                summaryMenu.Elements.Add(new MenuText(character.MaxHP.ToString(),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
+                text_start += max_hp_length + remaining_width / 3 + (character.MaxHP.ToString().StartsWith("1") ? 2 : 0);
+                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HUNGER"), 
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
+                text_start += hunger_label_length + max_fullness_length + 2;
+                summaryMenu.Elements.Add(new MenuText(character.Fullness.ToString(),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Right));
+                text_start += 4;
+                summaryMenu.Elements.Add(new MenuText("/",
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
+                text_start += character.MaxFullness.ToString().StartsWith("1") ? 2 : 4;
+                summaryMenu.Elements.Add(new MenuText(character.MaxFullness.ToString(),
+                    new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
             }
             
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance && !inReplay)
             {
-                int timerStart = GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + level_length + hp_length + remaining_width + hunger_length / 2;
+                int timerStart = GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + level_length + hp_length + remaining_width;
                 menuTimer = new MenuText(Text.FormatKey("MENU_TIMER", DataManager.Instance.Save.GetDungeonTimeDisplay()),
-                    new Loc(timerStart, GraphicsManager.MenuBG.TileHeight), DirH.None);
+                    new Loc(timerStart, GraphicsManager.MenuBG.TileHeight), DirH.Left);
                 summaryMenu.Elements.Add(menuTimer);
             }
         }

--- a/RogueEssence/Menu/Records/TeamResultsMenu.cs
+++ b/RogueEssence/Menu/Records/TeamResultsMenu.cs
@@ -27,7 +27,7 @@ namespace RogueEssence.Menu
             Div = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + LINE_HEIGHT), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
 
             EventedList<Character> charList = GetChars();
-            Stats = new MenuText[charList.Count * 4];
+            Stats = new MenuText[charList.Count * 5];
             Portraits = new SpeakerPortrait[charList.Count];
             for (int ii = 0; ii < charList.Count; ii++)
             {
@@ -37,21 +37,23 @@ namespace RogueEssence.Menu
                 Portraits[ii] = new SpeakerPortrait(character.BaseForm, new EmoteStyle(0),
                     new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + 44 * ii + TitledStripMenu.TITLE_OFFSET), false);
                 string speciesText = character.BaseName + " / " + CharData.GetFullFormName(character.BaseForm);
-                Stats[ii * 4] = new MenuText(speciesText,
+                Stats[ii * 5] = new MenuText(speciesText,
                     new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + 44 * ii + TitledStripMenu.TITLE_OFFSET));
-                Stats[ii * 4 + 1] = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level),
-                    new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2 - 24, GraphicsManager.MenuBG.TileHeight + 44 * ii + TitledStripMenu.TITLE_OFFSET));
+                Stats[ii * 5 + 1] = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"),
+                    new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2 - 16, GraphicsManager.MenuBG.TileHeight + 44 * ii + TitledStripMenu.TITLE_OFFSET), DirH.Right);
+                Stats[ii * 5 + 2] = new MenuText(character.Level.ToString(),
+                    new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2 - 16 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), GraphicsManager.MenuBG.TileHeight + 44 * ii + TitledStripMenu.TITLE_OFFSET), DirH.Right);
                 if (Ending.UUID == character.OriginalUUID)
                 {
-                    Stats[ii * 4 + 2] = new MenuText(Text.FormatKey("MENU_TEAM_MET_AT", character.MetAt),
+                    Stats[ii * 5 + 3] = new MenuText(Text.FormatKey("MENU_TEAM_MET_AT", character.MetAt),
                     new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE + 44 * ii + TitledStripMenu.TITLE_OFFSET));
                 }
                 else
                 {
-                    Stats[ii * 4 + 2] = new MenuText(Text.FormatKey("MENU_TEAM_TRADED_FROM", character.OriginalTeam),
+                    Stats[ii * 5 + 3] = new MenuText(Text.FormatKey("MENU_TEAM_TRADED_FROM", character.OriginalTeam),
                     new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE + 44 * ii + TitledStripMenu.TITLE_OFFSET));
                 }
-                Stats[ii * 4 + 3] = new MenuText((String.IsNullOrEmpty(character.DefeatAt) ? "" : Text.FormatKey("MENU_TEAM_FELL_AT", character.DefeatAt)),
+                Stats[ii * 5 + 4] = new MenuText((String.IsNullOrEmpty(character.DefeatAt) ? "" : Text.FormatKey("MENU_TEAM_FELL_AT", character.DefeatAt)),
                     new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + 44 * ii + TitledStripMenu.TITLE_OFFSET));
 
                 base.Initialize();

--- a/RogueEssence/Menu/Skills/TutorTeamMenu.cs
+++ b/RogueEssence/Menu/Skills/TutorTeamMenu.cs
@@ -28,8 +28,9 @@ namespace RogueEssence.Menu
                 int teamIndex = team.Count;
 
                 MenuText memberName = new MenuText(character.GetDisplayName(true), new Loc(2, 1), Color.White);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1), DirV.Up, DirH.Right, Color.White);
-                team.Add(new MenuElementChoice(() => { choose(teamIndex); }, true, memberName, memberLv));
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(menuWidth - 8 * 7 + 6, 1), DirV.Up, DirH.Right, Color.White);
+                MenuText memberLv = new MenuText(character.Level.ToString(), memberLvLabel.Loc + new Loc(GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 0), DirV.Up, DirH.Right, Color.White);
+                team.Add(new MenuElementChoice(() => { choose(teamIndex); }, true, memberName, memberLvLabel, memberLv));
             }
 
             summaryMenu = new TeamMiniSummary(Rect.FromPoints(new Loc(16,

--- a/RogueEssence/Menu/Team/AddToTeamMenu.cs
+++ b/RogueEssence/Menu/Team/AddToTeamMenu.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
 using RogueElements;
+using RogueEssence.Data;
 using RogueEssence.Dungeon;
 
 namespace RogueEssence.Menu
@@ -30,9 +31,11 @@ namespace RogueEssence.Menu
                 int index = ii;
                 Character character = DungeonScene.Instance.ActiveTeam.Assembly[index];
                 MenuText memberName = new MenuText(character.GetDisplayName(true), new Loc(2, 1), character.Dead ? Color.Red : Color.White);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1),
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(menuWidth - 8 * 7 + 6, 1),
                     DirV.Up, DirH.Right, character.Dead ? Color.Red : Color.White);
-                flatChoices.Add(new MenuElementChoice(() => { choose(index); }, !character.Dead, memberName, memberLv));
+                MenuText memberLv = new MenuText(character.Level.ToString(), new Loc(menuWidth - 8 * 7 + 6 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 1),
+                    DirV.Up, DirH.Right, character.Dead ? Color.Red : Color.White);
+                flatChoices.Add(new MenuElementChoice(() => { choose(index); }, !character.Dead, memberName, memberLvLabel, memberLv));
             }
             IChoosable[][] box = SortIntoPages(flatChoices.ToArray(), SLOTS_PER_PAGE);
 

--- a/RogueEssence/Menu/Team/AssemblyMenu.cs
+++ b/RogueEssence/Menu/Team/AssemblyMenu.cs
@@ -32,9 +32,11 @@ namespace RogueEssence.Menu
                 Character character = DataManager.Instance.Save.ActiveTeam.Players[index];
                 bool enabled = !ChoosingLeader(ii);
                 MenuText memberName = new MenuText(character.BaseName, new Loc(2, 1), enabled ? Color.Lime : TextIndigo);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1),
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(menuWidth - 8 * 7 + 6, 1),
                     DirV.Up, DirH.Right, enabled ? Color.Lime : TextIndigo);
-                flatChoices.Add(new MenuElementChoice(() => { Choose(index, false); }, true, memberName, memberLv));
+                MenuText memberLv = new MenuText(character.Level.ToString(), new Loc(menuWidth - 8 * 7 + 6 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 1), 
+                    DirV.Up, DirH.Right, enabled ? Color.Lime : TextIndigo);
+                flatChoices.Add(new MenuElementChoice(() => { Choose(index, false); }, true, memberName, memberLvLabel, memberLv));
             }
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Assembly.Count; ii++)
             {
@@ -42,9 +44,11 @@ namespace RogueEssence.Menu
                 Character character = DataManager.Instance.Save.ActiveTeam.Assembly[index];
                 Color color = CanChooseAssembly(ii) ? (character.IsFavorite ? Color.Yellow : Color.White) : Color.Red;
                 MenuText memberName = new MenuText(character.BaseName, new Loc(2, 1), color);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1),
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(menuWidth - 8 * 7 + 6, 1),
                     DirV.Up, DirH.Right, color);
-                flatChoices.Add(new MenuElementChoice(() => { Choose(index, true); }, true, memberName, memberLv));
+                MenuText memberLv = new MenuText(character.Level.ToString(), new Loc(menuWidth - 8 * 7 + 6 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 1), DirV.Up, DirH.Right, color);
+                
+                flatChoices.Add(new MenuElementChoice(() => { Choose(index, true); }, true, memberName, memberLvLabel, memberLv));
             }
             IChoosable[][] box = SortIntoPages(flatChoices.ToArray(), SLOTS_PER_PAGE);
             defaultChoice = Math.Min(defaultChoice, flatChoices.Count - 1);

--- a/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
+++ b/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
@@ -20,8 +20,14 @@ namespace RogueEssence.Menu
 
         public SpeakerPortrait Portrait;
         public MenuText Name;
+
+        public MenuText LevelLabel;
         public MenuText Level;
+
+        public MenuText HPLabel;
         public MenuText HP;
+
+        public MenuText FullnessLabel;
         public MenuText Fullness;
 
         public MenuText Elements;
@@ -69,11 +75,14 @@ namespace RogueEssence.Menu
             origElements &= (player.Element2 == DataManager.Instance.GetMonster(player.BaseForm.Species).Forms[player.BaseForm.Form].Element2);
             Elements = new MenuText(Text.FormatKey("MENU_TEAM_ELEMENT", typeString), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 1 + TitledStripMenu.TITLE_OFFSET), origElements ? Color.White : Color.Yellow);
 
-            Level = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", player.Level), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + TitledStripMenu.TITLE_OFFSET));
+            LevelLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + TitledStripMenu.TITLE_OFFSET));
+            Level = new MenuText(player.Level.ToString(), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_LEVEL_SHORT")), GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + TitledStripMenu.TITLE_OFFSET), DirH.Left);
 
-
-            HP = new MenuText(Text.FormatKey("MENU_TEAM_HP", player.HP, player.MaxHP), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + TitledStripMenu.TITLE_OFFSET));
-            Fullness = new MenuText(Text.FormatKey("MENU_TEAM_HUNGER", player.Fullness, player.MaxFullness), new Loc((Bounds.End.X - Bounds.X) / 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + TitledStripMenu.TITLE_OFFSET));
+            HPLabel = new MenuText(Text.FormatKey("MENU_TEAM_HP"), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + TitledStripMenu.TITLE_OFFSET));
+            HP = new MenuText(String.Format("{0}/{1}", player.HP, player.MaxHP), new Loc( GraphicsManager.MenuBG.TileWidth * 2 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HP")) + 4, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + TitledStripMenu.TITLE_OFFSET), DirH.Left);
+            
+            FullnessLabel = new MenuText(Text.FormatKey("MENU_TEAM_HUNGER"), new Loc((Bounds.End.X - Bounds.X) / 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + TitledStripMenu.TITLE_OFFSET));
+            Fullness = new MenuText(String.Format("{0}/{1}", player.Fullness, player.MaxFullness), new Loc((Bounds.End.X - Bounds.X) / 2 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HUNGER")) + 4, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + TitledStripMenu.TITLE_OFFSET), DirH.Left);
 
             MainDiv = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 5), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
 
@@ -114,10 +123,16 @@ namespace RogueEssence.Menu
 
             yield return Portrait;
             yield return Name;
-            
+
+            yield return LevelLabel;
             yield return Level;
+            
             yield return Elements;
+
+            yield return HPLabel;
             yield return HP;
+
+            yield return FullnessLabel;
             yield return Fullness;
 
             yield return MainDiv;

--- a/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
+++ b/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
@@ -39,12 +39,14 @@ namespace RogueEssence.Menu
                 string skill = levelUpSkill.Skill;
                 SkillData skillEntry = DataManager.Instance.GetSkill(levelUpSkill.Skill);
 
+
                 MenuText skillText = new MenuText(skillEntry.GetIconName(), new Loc(1, 1), Color.White);
-                MenuText levelUpText = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", levelUpSkill.Level),
-                    new Loc(GraphicsManager.ScreenWidth - 72, 1), DirV.Up, DirH.Right, Color.White);
+                MenuText levelLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"),
+                    new Loc(GraphicsManager.ScreenWidth - 88, 1), DirH.Right);
+                MenuText level = new MenuText(levelUpSkill.Level.ToString(), new Loc(GraphicsManager.ScreenWidth - 88 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 0), DirH.Right);
 
                 Skills.Add(skill);
-                flatChoices.Add(new MenuElementChoice(() => { }, true, levelUpText, skillText));
+                flatChoices.Add(new MenuElementChoice(() => { }, true, levelLabel, level, skillText));
             }
 
             IChoosable[][] choices = SortIntoPages(flatChoices.ToArray(), SLOTS_PER_PAGE);

--- a/RogueEssence/Menu/Team/MemberStatsMenu.cs
+++ b/RogueEssence/Menu/Team/MemberStatsMenu.cs
@@ -20,6 +20,7 @@ namespace RogueEssence.Menu
 
         public SpeakerPortrait Portrait;
         public MenuText Name;
+        public MenuText LevelLabel;
         public MenuText Level;
         public MenuText EXP;
 
@@ -88,8 +89,9 @@ namespace RogueEssence.Menu
             origElements &= (player.Element2 == monsterForm.Element2);
             Elements = new MenuText(Text.FormatKey("MENU_TEAM_ELEMENT", typeString), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 1 + TitledStripMenu.TITLE_OFFSET), origElements ? Color.White : Color.Yellow);
 
-            Level = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", player.Level), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + TitledStripMenu.TITLE_OFFSET));
-
+            LevelLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + TitledStripMenu.TITLE_OFFSET));
+            Level = new MenuText(player.Level.ToString(),  new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_LEVEL_SHORT")), GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2 + TitledStripMenu.TITLE_OFFSET), DirH.Left);
+            
             int expToNext = 0;
             if (player.Level < DataManager.Instance.MaxLevel)
             {
@@ -169,6 +171,7 @@ namespace RogueEssence.Menu
             yield return Portrait;
             yield return Name;
 
+            yield return LevelLabel;
             yield return Level;
             yield return Elements;
             yield return EXP;

--- a/RogueEssence/Menu/Team/MemberStatsMenu.cs
+++ b/RogueEssence/Menu/Team/MemberStatsMenu.cs
@@ -68,7 +68,7 @@ namespace RogueEssence.Menu
             int totalOtherMemberPages = 3;
             int totalPages = totalLearnsetPages + totalOtherMemberPages;
             
-            Title = new MenuText(Text.FormatKey("MENU_STATS_TITLE") + $" (2/{totalPages})", new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
+            Title = new MenuText(Text.FormatKey("MENU_STATS_TITLE"), new Loc(GraphicsManager.MenuBG.TileWidth + 8, GraphicsManager.MenuBG.TileHeight));
             PageText = new MenuText($"(2/{totalPages})", new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight), DirH.Right);
             Div = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + LINE_HEIGHT), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
 

--- a/RogueEssence/Menu/Team/OfferFeaturesMenu.cs
+++ b/RogueEssence/Menu/Team/OfferFeaturesMenu.cs
@@ -13,6 +13,7 @@ namespace RogueEssence.Menu
         public SpeakerPortrait Portrait;
         public MenuText Nickname;
         public MenuText Name;
+        public MenuText LevelLabel;
         public MenuText Level;
 
         public MenuText Elements;
@@ -38,8 +39,8 @@ namespace RogueEssence.Menu
             Nickname = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight));
             Name = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE));
 
-            Level = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
-
+            LevelLabel = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
+            Level = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2 + 48 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2), DirH.Left);
             Elements = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3));
 
             MainDiv = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 4 - 2), Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
@@ -67,7 +68,9 @@ namespace RogueEssence.Menu
 
             BaseMonsterForm formData = DataManager.Instance.GetMonster(CurrentChar.BaseForm.Species).Forms[CurrentChar.BaseForm.Form];
 
-            Level.SetText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", CurrentChar.Level));
+            LevelLabel.SetText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"));
+            Level.SetText(CurrentChar.Level.ToString());
+            
             ElementData element1 = DataManager.Instance.GetElement(formData.Element1);
             ElementData element2 = DataManager.Instance.GetElement(formData.Element2);
             string typeString = element1.GetIconName();
@@ -99,6 +102,7 @@ namespace RogueEssence.Menu
             yield return Nickname;
             yield return Name;
 
+            yield return LevelLabel;
             yield return Level;
             yield return Elements;
 

--- a/RogueEssence/Menu/Team/PromoteMenu.cs
+++ b/RogueEssence/Menu/Team/PromoteMenu.cs
@@ -28,8 +28,9 @@ namespace RogueEssence.Menu
                 int teamIndex = team.Count;
 
                 MenuText memberName = new MenuText(character.GetDisplayName(true), new Loc(2, 1), Color.White);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1), DirV.Up, DirH.Right, Color.White);
-                team.Add(new MenuElementChoice(() => { choose(teamIndex); }, true, memberName, memberLv));
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(menuWidth - 8 * 6, 1), DirV.Up, DirH.Right, Color.White);
+                MenuText memberLv = new MenuText(character.Level.ToString(), new Loc(menuWidth - 8 * 7 + 6 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 1), DirV.Up, DirH.Right, Color.White);
+                team.Add(new MenuElementChoice(() => { choose(teamIndex); }, true, memberName, memberLvLabel, memberLv));
             }
 
             summaryMenu = new TeamMiniSummary(Rect.FromPoints(new Loc(16,

--- a/RogueEssence/Menu/Team/TeamMenu.cs
+++ b/RogueEssence/Menu/Team/TeamMenu.cs
@@ -61,9 +61,12 @@ namespace RogueEssence.Menu
                         disabled |= DataManager.Instance.GetSkin(character.BaseForm.Skin).Challenge && !character.Dead;
                 }
 
-                MenuText memberName = new MenuText(character.GetDisplayName(true), new Loc(2, 1), disabled ? Color.Red : Color.White);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1), DirV.Up, DirH.Right, disabled ? Color.Red : Color.White);
-                team.Add(new MenuElementChoice(() => { choose(teamIndex); }, !disabled, memberName, memberLv));
+                Color color = disabled ? Color.Red : Color.White;
+                MenuText memberName = new MenuText(character.GetDisplayName(true), new Loc(2, 1), color);
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"), new Loc(menuWidth - 8 * 7 + 6, 1), DirV.Up, DirH.Right, color);
+                MenuText memberLv = new MenuText(character.Level.ToString(), new Loc(menuWidth - 8 * 7 + 6 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 1), DirV.Up, DirH.Right, color);
+
+                team.Add(new MenuElementChoice(() => { choose(teamIndex); }, !disabled, memberName, memberLvLabel, memberLv));
             }
 
             summaryMenu = new TeamMiniSummary(Rect.FromPoints(new Loc(16,

--- a/RogueEssence/Menu/Team/TeamMiniSummary.cs
+++ b/RogueEssence/Menu/Team/TeamMiniSummary.cs
@@ -9,8 +9,11 @@ namespace RogueEssence.Menu
     public class TeamMiniSummary : SummaryMenu
     {
         MenuText FullName;
+        MenuText LevelLabel;
         MenuText Level;
+        MenuText HPLabel;
         MenuText HP;
+        MenuText FullnessLabel;
         MenuText Fullness;
         MenuText EXP;
         MenuText Intrinsics;
@@ -20,12 +23,18 @@ namespace RogueEssence.Menu
         {
             FullName = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight));
             Elements.Add(FullName);
-            Level = new MenuText("", new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight), DirH.Right);
+            LevelLabel = new MenuText("", new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 6, GraphicsManager.MenuBG.TileHeight));
+            Elements.Add(LevelLabel);
+            Level = new MenuText("", new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 6 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_LEVEL_SHORT")), GraphicsManager.MenuBG.TileHeight), DirH.Left);
             Elements.Add(Level);
-            HP = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE));
+            HPLabel = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE));
+            Elements.Add(HPLabel);
+            HP = new MenuText("", new Loc( GraphicsManager.MenuBG.TileWidth * 2 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HP")) + 4, GraphicsManager.MenuBG.TileHeight + VERT_SPACE), DirH.Left);
             Elements.Add(HP);
 
-            Fullness = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
+            FullnessLabel = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
+            Elements.Add(FullnessLabel);
+            Fullness = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2 + GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HUNGER")) + 4, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2), DirH.Left);
             Elements.Add(Fullness);
             EXP = new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3));
             Elements.Add(EXP);
@@ -36,9 +45,13 @@ namespace RogueEssence.Menu
         public void SetMember(Character character)
         {
             FullName.SetText(character.GetDisplayName(true) + " / " + CharData.GetFullFormName(character.BaseForm));
-            Level.SetText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level));
-            HP.SetText(Text.FormatKey("MENU_TEAM_HP", character.HP, character.MaxHP));
-            Fullness.SetText(Text.FormatKey("MENU_TEAM_HUNGER", character.Fullness, character.MaxFullness));
+            LevelLabel.SetText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"));
+            Level.SetText(character.Level.ToString());
+            HPLabel.SetText(Text.FormatKey("MENU_TEAM_HP"));
+            HP.SetText(String.Format("{0}/{1}", character.HP, character.MaxHP));
+            
+            FullnessLabel.SetText(Text.FormatKey("MENU_TEAM_HUNGER"));
+            Fullness.SetText(String.Format("{0}/{1}", character.Fullness, character.MaxFullness));
 
             int expToNext = 0;
             if (character.Level < DataManager.Instance.MaxLevel)

--- a/RogueEssence/Menu/Team/TradeTeamMenu.cs
+++ b/RogueEssence/Menu/Team/TradeTeamMenu.cs
@@ -36,9 +36,11 @@ namespace RogueEssence.Menu
                 Character character = DataManager.Instance.Save.ActiveTeam.Assembly[index];
                 bool tradeable = !character.IsFounder && !character.IsFavorite;
                 MenuText memberName = new MenuText(character.GetDisplayName(true), new Loc(2, 1), tradeable ? Color.White : Color.Red);
-                MenuText memberLv = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 4, 1),
+                MenuText memberLvLabel = new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT", character.Level), new Loc(menuWidth - 8 * 7 + 6, 1),
                     DirV.Up, DirH.Right, tradeable ? Color.White : Color.Red);
-                flatChoices.Add(new MenuElementChoice(() => { choose(index); }, tradeable, memberName, memberLv));
+                MenuText memberLv = new MenuText(character.Level.ToString(), new Loc(menuWidth - 8 * 7 + 6 + GraphicsManager.TextFont.SubstringWidth(DataManager.Instance.MaxLevel.ToString()), 1),
+                    DirV.Up, DirH.Right, tradeable ? Color.White : Color.Red);
+                flatChoices.Add(new MenuElementChoice(() => { choose(index); }, tradeable, memberName, memberLvLabel, memberLv));
             }
             IChoosable[][] box = SortIntoPages(flatChoices.ToArray(), SLOTS_PER_PAGE);
 


### PR DESCRIPTION
Removes the number in strings such as `MENU_TEAM_LEVEL_SHORT` and adds a new MenuText for such instances

The only that needs to be looked at is the TradeMenus and making sure everything is formatted correctly there.

Also requires the number component to be removed MENU_TEAM_LEVEL_SHORT, MENU_TEAM_HUNGER, and MENU_TEAM_HP in all localities