### PR TITLE
Add speed and emote text tag

### DIFF
--- a/RogueEssence/Menu/Dialogue/DialogueBox.cs
+++ b/RogueEssence/Menu/Dialogue/DialogueBox.cs
@@ -37,6 +37,9 @@ namespace RogueEssence.Menu
         public List<List<TextScript>> ScriptCalls;
         protected List<TextScript> CurrentScript { get { return ScriptCalls[curTextIndex]; } }
 
+        public List<List<TextSpeed>> Speeds;
+        protected List<TextSpeed> CurrentSpeed { get { return Speeds[curTextIndex]; } }
+        
         //Dialogue Text needs to be able to set character index accurately
         protected List<DialogueText> Texts;
         private int curTextIndex;
@@ -68,6 +71,8 @@ namespace RogueEssence.Menu
         //message with pauses, without speaker name
         private string message;
 
+        private double currSpeed;
+
         public bool IsCheckpoint { get { return false; } }
         public bool Inactive { get; set; }
         public bool BlockPrevious { get; set; }
@@ -78,6 +83,7 @@ namespace RogueEssence.Menu
 
             Pauses = new List<List<TextPause>>();
             ScriptCalls = new List<List<TextScript>>();
+            Speeds = new List<List<TextSpeed>>();
             speakerName = "";
 
             Sound = sound;
@@ -111,7 +117,12 @@ namespace RogueEssence.Menu
                     //TODO: execute callback and wait for its completion
                     CurrentScript.RemoveAt(0);
                 }
-
+                TextSpeed textSpeed = getCurrentTextSpeed();
+                if (textSpeed != null)
+                {
+                    currSpeed = textSpeed.Speed;
+                    CurrentSpeed.RemoveAt(0);
+                }
                 TextPause textPause = getCurrentTextPause();
                 if (textPause != null)
                 {
@@ -133,7 +144,9 @@ namespace RogueEssence.Menu
                 }
 
                 bool addedText = false;
-                FrameTick subTick = DialogueBox.TextSpeed > 0 ? new FrameTick((long)(FrameTick.FrameToTick(1) / DialogueBox.TextSpeed)) : FrameTick.FromFrames(1);
+                
+                double speed = currSpeed > 0 ? currSpeed : DialogueBox.TextSpeed;
+                FrameTick subTick = speed > 0 ? new FrameTick((long)(FrameTick.FrameToTick(1) / speed)) : FrameTick.FromFrames(1);
                 while (true)
                 {
                     if (CurrentText.Finished || getCurrentTextScript() != null || getCurrentTextPause() != null)
@@ -231,6 +244,16 @@ namespace RogueEssence.Menu
             }
             return null;
         }
+        
+        protected TextSpeed getCurrentTextSpeed()
+        {
+            if (CurrentSpeed.Count > 0)
+            {
+                if (CurrentText.CurrentCharIndex < 0 || CurrentSpeed[0].LetterIndex <= CurrentText.CurrentCharIndex)
+                    return CurrentSpeed[0];
+            }
+            return null;
+        }
 
         protected TextScript getCurrentTextScript()
         {
@@ -285,6 +308,7 @@ namespace RogueEssence.Menu
             curTextIndex = 0;
             nextTextIndex = -1;
             Pauses.Clear();
+            Speeds.Clear();
             ScriptCalls.Clear();
 
             int curCharIndex = 0;
@@ -302,8 +326,11 @@ namespace RogueEssence.Menu
                 List<TextPause> pauses = new List<TextPause>();
                 List<TextScript> scripts = new List<TextScript>();
                 List<IntRange> tagRanges = new List<IntRange>();
+                List<TextSpeed> speeds = new List<TextSpeed>();
+                
                 int lag = 0;
                 MatchCollection matches = Text.MsgTags.Matches(scrolls[nn]);
+                
                 foreach (Match match in matches)
                 {
                     foreach (string key in match.Groups.Keys)
@@ -334,6 +361,17 @@ namespace RogueEssence.Menu
                                     tagRanges.Add(new IntRange(match.Index, match.Index + match.Length));
                                 }
                                 break;
+                            case "speed":
+                                {
+                                    TextSpeed speed = new TextSpeed();
+                                    speed.LetterIndex = match.Index - lag;
+                                    double param;
+                                    if (Double.TryParse(match.Groups["speedval"].Value, out param))
+                                        speed.Speed = param;
+                                    speeds.Add(speed);
+                                    tagRanges.Add(new IntRange(match.Index, match.Index + match.Length));
+                                }
+                                break;
                             case "colorstart":
                             case "colorend":
                                 break;
@@ -356,6 +394,7 @@ namespace RogueEssence.Menu
                 int totalLength = 0;
                 int curPause = 0;
                 int curScript = 0;
+                int curSpeed = 0;
                 for (int kk = 0; kk < texts.Count; kk++)
                 {
                     DialogueText text = texts[kk];
@@ -363,6 +402,7 @@ namespace RogueEssence.Menu
                     //pauses and scripts need to be re-aligned to the removals done by breaking the text into lines
                     List<TextPause> subPauses = new List<TextPause>();
                     List<TextScript> subScripts = new List<TextScript>();
+                    List<TextSpeed> subSpeeds = new List<TextSpeed>();
 
                     int lineCount = text.GetLineCount();
                     for (int ii = 0; ii < lineCount; ii++)
@@ -392,11 +432,24 @@ namespace RogueEssence.Menu
                             else
                                 break;
                         }
+                        
+                        for (; curSpeed < speeds.Count; curSpeed++)
+                        {
+                            TextSpeed speed = speeds[curSpeed];
+                            if (speed.LetterIndex <= totalLength)
+                            {
+                                speed.LetterIndex -= totalTrim;
+                                subSpeeds.Add(speed);
+                            }
+                            else
+                                break;
+                        }
                     }
                     totalTrim = totalLength;
 
                     Pauses.Add(subPauses);
                     ScriptCalls.Add(subScripts);
+                    Speeds.Add(subSpeeds);
                     Texts.Add(text);
                 }
 
@@ -409,6 +462,12 @@ namespace RogueEssence.Menu
     {
         public int LetterIndex;
         public int Time;//1 in order to wait on button press
+    }
+    
+    public class TextSpeed
+    {
+        public int LetterIndex;
+        public double Speed;
     }
 
     public class TextScript

--- a/RogueEssence/Menu/Dialogue/SpeakerPortrait.cs
+++ b/RogueEssence/Menu/Dialogue/SpeakerPortrait.cs
@@ -19,10 +19,18 @@ namespace RogueEssence.Menu
             Speaker = speaker;
             SpeakerEmotion = emotion;
             Bordered = bordered;
-
             Loc = loc;
         }
-
+        public SpeakerPortrait(SpeakerPortrait other, int emote)
+        {
+            Speaker = other.Speaker;
+            SpeakerEmotion = other.SpeakerEmotion;
+            SpeakerEmotion.Emote = emote;
+            SpeakerEmotion.Reverse = other.SpeakerEmotion.Reverse;
+            Bordered = other.Bordered;
+            Loc = other.Loc;
+        }
+        
         //kind of like a menu, but not quite (uses borders)
         //draws the portrait
 

--- a/RogueEssence/Text.cs
+++ b/RogueEssence/Text.cs
@@ -35,9 +35,9 @@ namespace RogueEssence
                                                 @"|(?<colorstart>\[color=#(?<colorval>[0-9a-f]{6})\])|(?<colorend>\[color\])" +
                                                 @"|(?<boxbreak>\[br\])" +
                                                 @"|(?<speed>\[speed=(?<speedval>[+-]?\d+\.?\d*)\])" + 
+                                                @"|(?<emote>\[emote=(?<emoteval>\d*|[a-zA-Z]*)\])" + 
                                                 @"|(?<script>\[script=(?<scriptval>\d+)\])",
                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        //
 
         public static void Init()
         {

--- a/RogueEssence/Text.cs
+++ b/RogueEssence/Text.cs
@@ -34,9 +34,10 @@ namespace RogueEssence
         public static Regex MsgTags = new Regex(@"(?<pause>\[pause=(?<pauseval>\d+)\])" +
                                                 @"|(?<colorstart>\[color=#(?<colorval>[0-9a-f]{6})\])|(?<colorend>\[color\])" +
                                                 @"|(?<boxbreak>\[br\])" +
-                                                @"|(?<scrollbreak>\[scroll\])" +
-                                                @"(?<script>\[script=(?<scriptval>\d+)\])",
+                                                @"|(?<speed>\[speed=(?<speedval>[+-]?\d+\.?\d*)\])" + 
+                                                @"|(?<script>\[script=(?<scriptval>\d+)\])",
                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        //
 
         public static void Init()
         {


### PR DESCRIPTION
Add two new text tags: `speed` and `emote`

Usage:
**Does not update** `DialogueBox.TextSpeed`
`[speed=6]` - Sets the speed for the rest of WaitShowDialogue() to be 6

**Does not update** `m_curspeakerEmo.Emote`
`[emote=0]` - Sets the emote for the portrait to be Normal (or whatever the emote is at index 0)
`[emote=Joyous]` - Sets the emote for the portrait to be Joyous for the current character

