### PR TITLE
absent anim

### DIFF
--- a/RogueEssence/Dungeon/Characters/CharAction.cs
+++ b/RogueEssence/Dungeon/Characters/CharAction.cs
@@ -75,6 +75,7 @@ namespace RogueEssence.Dungeon
         public bool MajorAction { get { return currentAnim.MajorAnim; } }
         public bool ActionPassed { get { return currentAnim.ActionPassed; } }
         public Loc DrawOffset { get { return currentAnim.DrawOffset; } }
+        public bool HideShadow { get { return currentAnim.HideShadow; } }
         public IEnumerable<Loc> GetLocsVisible() { return currentAnim.GetLocsVisible(); }
         public IEnumerable<VisionLoc> GetVisionLocs() { return currentAnim.GetVisionLocs(); }
 

--- a/RogueEssence/Dungeon/Characters/CharAnimation.cs
+++ b/RogueEssence/Dungeon/Characters/CharAnimation.cs
@@ -26,6 +26,8 @@ namespace RogueEssence.Dungeon
         protected abstract int AnimFrameType { get; }
         protected virtual int FrameMethod(List<CharAnimFrame> frames) { return zeroFrame(frames); }
 
+        public bool HideShadow { get; set; }
+        
         public bool MajorAnim { get; set; }
         public abstract Loc CharLoc { get; set; }
 
@@ -307,6 +309,16 @@ namespace RogueEssence.Dungeon
         public int BaseFrameType { get; set; }
         protected override int AnimFrameType { get { return BaseFrameType; } }
         public IdleAnimAction(Loc loc, Dir8 dir, int frameType) : base(loc, dir) { AnimLoc = loc; CharDir = dir; BaseFrameType = frameType; }
+    }
+    
+    public class CharAbsentAnim : CharAnimIdle
+    {
+        public CharAbsentAnim(Loc loc, Dir8 dir) : base(loc, dir) { AnimLoc = loc; CharDir = dir; HideShadow = true; }
+        protected override void UpdateFrameInternal()
+        {
+            MapLoc = VisualLoc * GraphicsManager.TileSize;
+            opacity = 0;
+        }
     }
 
     public class CharAnimPose : StaticCharAnimation

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -230,6 +230,11 @@ namespace RogueEssence.Dungeon
             set { currentCharAction.CharDir = value; }
         }
 
+        public bool HideShadow
+        {
+            get { return currentCharAction.HideShadow; }
+        }
+        
         public int HP;
         public int HPRemainder;
 
@@ -2444,7 +2449,7 @@ namespace RogueEssence.Dungeon
                     yield break;
                 }
             }
-
+            
             CharAction prevAction = currentCharAction;
             CharAction newCharAction = new EmptyCharAction(charAnim);
             newCharAction.PickUpFrom(Appearance.ToCharID(), currentCharAction);
@@ -2561,6 +2566,9 @@ namespace RogueEssence.Dungeon
 
         public void DrawShadow(SpriteBatch spriteBatch, Loc offset, int terrainShadow)
         {
+            if (HideShadow)
+                return;
+            
             CharSheet sheet = GraphicsManager.GetChara(Appearance.ToCharID());
             int teamStatus = 2;
             //if (DataManager.Instance.Save != null || !DataManager.Instance.Save.CutsceneMode)


### PR DESCRIPTION
Adds `AbsentAnim`, which sets the opacity to 0 for all frames and prevents the shadow from being drawn using the added `HideShadow` member variable.

This is useful for warping out of dungeons effect in lua like so:

```lua
  local partymember = GAME:GetPlayerPartyMember(0)
  local anim = RogueEssence.Dungeon.CharAbsentAnim(partymember.CharLoc, partymember.CharDir)
  TASK:WaitTask(partymember:StartAnim(anim))
```