### PR TITLE
Scriptable main menu

### DIFF
--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -9,6 +9,7 @@ using RogueEssence.Dev;
 using RogueEssence.Menu;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using RogueEssence.Script;
 
 namespace RogueEssence.Dungeon
 {
@@ -350,7 +351,16 @@ namespace RogueEssence.Dungeon
                         ProcessMinimapInput(input);
                     else if (DataManager.Instance.CurrentReplay.OpenMenu)
                     {
-                        yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(new MainMenu()));
+                        MainMenu newMenu = new MainMenu();
+                        newMenu.SetupChoices();
+                        LuaEngine.Instance.OnMainMenuChoicesSet(newMenu);
+                        newMenu.SetupTitleAndSummary();
+                        LuaEngine.Instance.OnMainMenuCreated(newMenu);
+                        ReplaceableMenu replaceableMenu = new ReplaceableMenu();
+                        replaceableMenu.menu = newMenu;
+                        LuaEngine.Instance.OnMainMenuReplace(replaceableMenu);
+                        replaceableMenu.menu.InitMenu();
+                        yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(replaceableMenu.menu));
                         DataManager.Instance.CurrentReplay.OpenMenu = false;
                     }
                     else if (input.JustPressed(FrameInput.InputType.Attack))
@@ -411,7 +421,16 @@ namespace RogueEssence.Dungeon
                     GameManager.Instance.SE("Menu/Skip");
                     CurrentPreviewMove = -1;
                     Turn = false;
-                    yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(new MainMenu()));
+                    MainMenu newMenu = new MainMenu();
+                    newMenu.SetupChoices();
+                    LuaEngine.Instance.OnMainMenuChoicesSet(newMenu);
+                    newMenu.SetupTitleAndSummary();
+                    LuaEngine.Instance.OnMainMenuCreated(newMenu);
+                    ReplaceableMenu replaceableMenu = new ReplaceableMenu();
+                    replaceableMenu.menu = newMenu;
+                    LuaEngine.Instance.OnMainMenuReplace(replaceableMenu);
+                    replaceableMenu.menu.InitMenu();
+                    yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(replaceableMenu.menu));
                 }
                 else if (!input[FrameInput.InputType.Skills] && input.JustPressed(FrameInput.InputType.MsgLog))
                 {

--- a/RogueEssence/Ground/GroundScene.cs
+++ b/RogueEssence/Ground/GroundScene.cs
@@ -7,6 +7,7 @@ using RogueEssence.Menu;
 using RogueEssence.Dungeon;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using RogueEssence.Script;
 
 namespace RogueEssence.Ground
 {
@@ -168,7 +169,16 @@ namespace RogueEssence.Ground
             if (!input[FrameInput.InputType.Skills] && input.JustPressed(FrameInput.InputType.Menu))
             {
                 GameManager.Instance.SE("Menu/Skip");
-                yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(new MainMenu()));
+                MainMenu newMenu = new MainMenu();
+                newMenu.SetupChoices();
+                LuaEngine.Instance.OnMainMenuChoicesSet(newMenu);
+                newMenu.SetupTitleAndSummary();
+                LuaEngine.Instance.OnMainMenuCreated(newMenu);
+                ReplaceableMenu replaceableMenu = new ReplaceableMenu();
+                replaceableMenu.menu = newMenu;
+                LuaEngine.Instance.OnMainMenuReplace(replaceableMenu);
+                replaceableMenu.menu.InitMenu();
+                yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(replaceableMenu.menu));
             }
             else if (input.JustPressed(FrameInput.InputType.SkillMenu))
             {
@@ -270,9 +280,7 @@ namespace RogueEssence.Ground
             if (action.Type != GameAction.ActionType.None)
                 yield return CoroutineManager.Instance.StartCoroutine(ProcessInput(action));
         }
-
-
-
+        
         public override void Update(FrameTick elapsedTime)
         {
 

--- a/RogueEssence/Lua/LuaEngine.cs
+++ b/RogueEssence/Lua/LuaEngine.cs
@@ -287,6 +287,15 @@ namespace RogueEssence.Script
             Deinit,
             GraphicsLoad,
             GraphicsUnload,
+            ItemMenuCreated,
+            TeamMenuCreated,
+            TacticsMenuCreated,
+            OthersMenuCreated,
+            RestMenuCreated,
+            ReplayMenuCreated,
+            MainMenuChoicesSet,
+            MainMenuCreated,
+            MainMenuReplace,
             NewGame,
             LossPenalty,
             UpgradeSave,
@@ -315,7 +324,7 @@ namespace RogueEssence.Script
             GroundMapExit,
 
             //Keep last
-            _NBEvents,
+            _NBEvents
         };
 
         private IEnumerator<EServiceEvents> IterateServiceEvents()
@@ -1713,7 +1722,8 @@ namespace RogueEssence.Script
             //}
 
             sb.Append(LuaState.GetDebugTraceback() + "\n");
-            return sb.ToString();
+            String returnString = sb.ToString();
+            return returnString;
         }
 
         /// <summary>
@@ -1783,6 +1793,73 @@ namespace RogueEssence.Script
             //Do stuff..
             DiagManager.Instance.LogInfo("LuaEngine.OnGraphicsUnload()..");
             m_scrsvc.Publish(EServiceEvents.GraphicsUnload.ToString());
+        }
+        
+
+        /// <summary>
+        /// These are called at the end of the constructor for the respective menu,
+        /// allowing modification for the completed menu.
+        /// Note that these are called after the menu is initialized, so change opportunities are limited for now.
+        /// </summary>
+        public void OnItemMenuCreated(ItemMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.ItemMenuCreated.ToString(), menu);
+        }
+
+        public void OnTacticsMenuCreated(TacticsMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.TacticsMenuCreated.ToString(), menu);
+        }
+        
+        public void OnTeamMenuCreated(TeamMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.TeamMenuCreated.ToString(), menu);
+        }
+        
+        public void OnRestMenuCreated(RestMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.RestMenuCreated.ToString(), menu);
+        }
+
+        public void OnReplayMenuCreated(ReplayMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.ReplayMenuCreated.ToString(), menu);
+        }
+        
+        /// <summary>
+        /// These are called after the menu is initialized.
+        /// </summary>
+        public void OnOthersMenuCreated(OthersMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.OthersMenuCreated.ToString(), menu);
+        }
+
+
+        /// <summary>
+        /// This is called after main menu choices are set, allowing for modification of menu choices (i.e. Moves, Items, Teams, etc.)
+        /// </summary>
+        public void OnMainMenuChoicesSet(MainMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.MainMenuChoicesSet.ToString(), menu);
+        }
+
+        /// <summary>
+        /// This is called after the main menu is created but before it is initialized.  Allows for modification of most things in the menu
+        /// </summary>
+        public void OnMainMenuCreated(MainMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.MainMenuCreated.ToString(), menu);
+        }
+        
+
+        /// <summary>
+        /// This is called after the main menu is created but before it is initialized.
+        /// Takes a ReplaceableMenu that takes an InteractableMenu (by default the main menu) as its "menu" data member.
+        /// Designed to allow the main menu to be completely swapped out.
+        /// </summary>
+        public void OnMainMenuReplace(ReplaceableMenu menu)
+        {
+            m_scrsvc.Publish(EServiceEvents.MainMenuReplace.ToString(), menu);
         }
 
         public void OnNewGame()

--- a/RogueEssence/Menu/InteractableMenu.cs
+++ b/RogueEssence/Menu/InteractableMenu.cs
@@ -14,6 +14,11 @@ namespace RogueEssence.Menu
 
         public abstract void Update(InputManager input);
 
+        //Overridden as needed, used for calling after a menu has been replaced
+        public virtual void InitMenu()
+        {
+            
+        }
         public void ProcessActions(FrameTick elapsedTime) { }
 
         public static bool IsInputting(InputManager input, params Dir8[] dirs)

--- a/RogueEssence/Menu/Items/ItemMenu.cs
+++ b/RogueEssence/Menu/Items/ItemMenu.cs
@@ -63,11 +63,13 @@ namespace RogueEssence.Menu
 
             int startPage = actualChoice / SLOTS_PER_PAGE;
             int startIndex = actualChoice % SLOTS_PER_PAGE;
-
-            Initialize(new Loc(16, 16), ITEM_MENU_WIDTH, (replaceSlot == -2) ? Text.FormatKey("MENU_ITEM_TITLE") : Text.FormatKey("MENU_ITEM_SWAP_TITLE"), inv, startIndex, startPage, SLOTS_PER_PAGE);
-
+            
             LuaEngine.Instance.OnItemMenuCreated(this);
+            
+            Initialize(new Loc(16, 16), ITEM_MENU_WIDTH, (replaceSlot == -2) ? Text.FormatKey("MENU_ITEM_TITLE") : Text.FormatKey("MENU_ITEM_SWAP_TITLE"), inv, startIndex, startPage, SLOTS_PER_PAGE);
         }
+        
+        
 
         private void choose(int choice)
         {

--- a/RogueEssence/Menu/Items/ItemMenu.cs
+++ b/RogueEssence/Menu/Items/ItemMenu.cs
@@ -7,6 +7,7 @@ using RogueElements;
 using RogueEssence.Dungeon;
 using RogueEssence.Data;
 using RogueEssence.Ground;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -65,6 +66,7 @@ namespace RogueEssence.Menu
 
             Initialize(new Loc(16, 16), ITEM_MENU_WIDTH, (replaceSlot == -2) ? Text.FormatKey("MENU_ITEM_TITLE") : Text.FormatKey("MENU_ITEM_SWAP_TITLE"), inv, startIndex, startPage, SLOTS_PER_PAGE);
 
+            LuaEngine.Instance.OnItemMenuCreated(this);
         }
 
         private void choose(int choice)

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -7,6 +7,7 @@ using RogueEssence.Content;
 using RogueEssence.Dungeon;
 using System;
 using RogueEssence.Ground;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -17,9 +18,21 @@ namespace RogueEssence.Menu
         private bool inReplay;
 
         MenuText menuTimer;
-        SummaryMenu titleMenu;
-        SummaryMenu summaryMenu;
+        
+        public List<MenuTextChoice> Choices { get; set; }
+        public List<IMenuElement> TitleElements { get; set; }
+        public List<IMenuElement> SummaryElements { get; set; }
+        
+        public int MenuWidth { get; set; }
+        public SummaryMenu TitleMenu { get; set; }
+        public Rect TitleMenuBounds { get; set; }
+        public SummaryMenu SummaryMenu { get; set; }
+        public Rect SummaryMenuBounds { get; set; }
         public MainMenu()
+        {
+        }
+
+        public void SetupChoices()
         {
             bool equippedItems = false;
             foreach (Character character in DataManager.Instance.Save.ActiveTeam.Players)
@@ -32,8 +45,8 @@ namespace RogueEssence.Menu
             }
             bool invEnabled = !(DataManager.Instance.Save.ActiveTeam.GetInvCount() == 0 && !equippedItems);
 
-            List<MenuTextChoice> choices = new List<MenuTextChoice>();
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SKILLS"), () =>
+            Choices = new List<MenuTextChoice>();
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SKILLS"), () =>
             {
                 int mainIndex = DataManager.Instance.Save.ActiveTeam.LeaderIndex;
                 if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
@@ -44,51 +57,63 @@ namespace RogueEssence.Menu
                 }
                 MenuManager.Instance.AddMenu(new SkillMenu(mainIndex), false);
             }));
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
 
             bool hasTactics = (DataManager.Instance.Save.ActiveTeam.Players.Count > 1);
             inReplay = (DataManager.Instance.CurrentReplay != null);
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {
                 bool hasGround = DungeonScene.Instance.CanCheckGround();
-                choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
+                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
             }
 
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(new OthersMenu(), false); }));
+            OthersMenu menu = new OthersMenu();
+            //Notify script engine
+            LuaEngine.Instance.OnOthersMenuCreated(menu);
+            menu.InitMenu();
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(menu, false); }));
 
             if (ZoneManager.Instance.InDevZone)
-                choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));
+                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));
             else if (!inReplay)
             {
                 if (((GameManager.Instance.CurrentScene == DungeonScene.Instance)) || DataManager.Instance.Save is RogueProgress)
-                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
+                    Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
                 else
-                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
+                    Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
             }
             else
-                choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_TITLE"), () => { MenuManager.Instance.AddMenu(new ReplayMenu(), false); }));
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
+            
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_TITLE"), () => { MenuManager.Instance.AddMenu(new ReplayMenu(), false); }));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
+        }
 
-            Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), choices.ToArray(), Math.Min(Math.Max(0, defaultChoice), choices.Count - 1));
-
-            titleMenu = new SummaryMenu(Rect.FromPoints(new Loc(Bounds.End.X + 16, 32), new Loc(GraphicsManager.ScreenWidth - 16, 32 + LINE_HEIGHT + GraphicsManager.MenuBG.TileHeight * 2)));
+        public void SetupTitleAndSummary()
+        {
+            MenuWidth = CalculateChoiceLength(Choices, 72);
+            
+            TitleElements = new List<IMenuElement>();
+            TitleMenuBounds = Rect.FromPoints(new Loc(MenuWidth + 16, 32),
+                new Loc(GraphicsManager.ScreenWidth - 16, 32 + LINE_HEIGHT + GraphicsManager.MenuBG.TileHeight * 2));
             MenuText title = new MenuText((GameManager.Instance.CurrentScene == DungeonScene.Instance) ? ZoneManager.Instance.CurrentMap.GetColoredName() : ZoneManager.Instance.CurrentGround.GetColoredName(),
-                new Loc(titleMenu.Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight), DirH.None);
-            titleMenu.Elements.Add(title);
-
-            summaryMenu = new SummaryMenu(Rect.FromPoints(new Loc(16, 32 + choices.Count * VERT_SPACE + GraphicsManager.MenuBG.TileHeight * 2),
-                new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8)));
-            summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_BAG_MONEY", Text.FormatKey("MONEY_AMOUNT", DataManager.Instance.Save.ActiveTeam.Money)),
+                new Loc(TitleMenuBounds.Width / 2, GraphicsManager.MenuBG.TileHeight), DirH.None);
+            TitleElements.Add(title);
+            
+            SummaryElements = new List<IMenuElement>();
+            SummaryMenuBounds = Rect.FromPoints(
+                new Loc(16, 32 + Choices.Count * VERT_SPACE + GraphicsManager.MenuBG.TileHeight * 2),
+                new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8));
+            SummaryElements.Add(new MenuText(Text.FormatKey("MENU_BAG_MONEY", Text.FormatKey("MONEY_AMOUNT", DataManager.Instance.Save.ActiveTeam.Money)),
                 new Loc(GraphicsManager.MenuBG.TileWidth + 4, GraphicsManager.MenuBG.TileHeight)));
             
             int level_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_LEVEL_SHORT") + $"{DataManager.Instance.Start.MaxLevel}");
             int hp_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HP") + $" {999}/{999}");
             int hunger_length = GraphicsManager.TextFont.SubstringWidth(Text.FormatKey("MENU_TEAM_HUNGER") + $" {Character.MAX_FULLNESS}/{Character.MAX_FULLNESS}");
 
-            int remaining_width = summaryMenu.Bounds.End.X - summaryMenu.Bounds.X - (GraphicsManager.MenuBG.TileWidth + 4) * 2 - level_length - hp_length - hunger_length - NicknameMenu.MAX_LENGTH;
+            int remaining_width = SummaryMenuBounds.End.X - SummaryMenuBounds.X - (GraphicsManager.MenuBG.TileWidth + 4) * 2 - level_length - hp_length - hunger_length - NicknameMenu.MAX_LENGTH;
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {
@@ -102,7 +127,7 @@ namespace RogueEssence.Menu
                         break;
                     }
                 }
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_MAP_CONDITION", weather),
+                SummaryElements.Add(new MenuText(Text.FormatKey("MENU_MAP_CONDITION", weather),
                     new Loc(GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + remaining_width / 3, GraphicsManager.MenuBG.TileHeight), DirH.Left));
             }
             
@@ -115,37 +140,37 @@ namespace RogueEssence.Menu
             {
                 Character character = DataManager.Instance.Save.ActiveTeam.Players[ii];
                 int text_start = GraphicsManager.MenuBG.TileWidth + 4;
-                summaryMenu.Elements.Add(new MenuText(character.GetDisplayName(true),
+                SummaryElements.Add(new MenuText(character.GetDisplayName(true),
                 new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT)));
                 text_start += NicknameMenu.MAX_LENGTH + remaining_width / 3;
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"),
+                SummaryElements.Add(new MenuText(Text.FormatKey("MENU_TEAM_LEVEL_SHORT"),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
                 text_start += level_length;
-                summaryMenu.Elements.Add(new MenuText(character.Level.ToString(),
+                SummaryElements.Add(new MenuText(character.Level.ToString(),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Right));
                 text_start += remaining_width / 3;
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HP"),
+                SummaryElements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HP"),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
                 text_start += hp_label_length + max_hp_length + 4;
-                summaryMenu.Elements.Add(new MenuText(character.HP.ToString(),
+                SummaryElements.Add(new MenuText(character.HP.ToString(),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Right));
                 text_start += 4;
-                summaryMenu.Elements.Add(new MenuText("/",
+                SummaryElements.Add(new MenuText("/",
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
                 text_start += character.MaxHP.ToString().StartsWith("1") ? 2 : 4;
-                summaryMenu.Elements.Add(new MenuText(character.MaxHP.ToString(),
+                SummaryElements.Add(new MenuText(character.MaxHP.ToString(),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
                 text_start += max_hp_length + remaining_width / 3 + (character.MaxHP.ToString().StartsWith("1") ? 2 : 0);
-                summaryMenu.Elements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HUNGER"), 
+                SummaryElements.Add(new MenuText(Text.FormatKey("MENU_TEAM_HUNGER"), 
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
                 text_start += hunger_label_length + max_fullness_length + 2;
-                summaryMenu.Elements.Add(new MenuText(character.Fullness.ToString(),
+                SummaryElements.Add(new MenuText(character.Fullness.ToString(),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Right));
                 text_start += 4;
-                summaryMenu.Elements.Add(new MenuText("/",
+                SummaryElements.Add(new MenuText("/",
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.None));
                 text_start += character.MaxFullness.ToString().StartsWith("1") ? 2 : 4;
-                summaryMenu.Elements.Add(new MenuText(character.MaxFullness.ToString(),
+                SummaryElements.Add(new MenuText(character.MaxFullness.ToString(),
                     new Loc(text_start, GraphicsManager.MenuBG.TileHeight + (ii + 1) * LINE_HEIGHT), DirH.Left));
             }
             
@@ -154,8 +179,19 @@ namespace RogueEssence.Menu
                 int timerStart = GraphicsManager.MenuBG.TileWidth + 4 + NicknameMenu.MAX_LENGTH + level_length + hp_length + remaining_width;
                 menuTimer = new MenuText(Text.FormatKey("MENU_TIMER", DataManager.Instance.Save.GetDungeonTimeDisplay()),
                     new Loc(timerStart, GraphicsManager.MenuBG.TileHeight), DirH.Left);
-                summaryMenu.Elements.Add(menuTimer);
+                SummaryElements.Add(menuTimer);
             }
+        }
+        
+        public override void InitMenu()
+        {
+            Initialize(new Loc(16, 16), MenuWidth, Choices.ToArray(), Math.Min(Math.Max(0, defaultChoice), Choices.Count - 1));
+
+             TitleMenu = new SummaryMenu(TitleMenuBounds);
+             TitleMenu.Elements = TitleElements;
+
+            SummaryMenu = new SummaryMenu(SummaryMenuBounds);
+            SummaryMenu.Elements = SummaryElements;
         }
 
         private void checkGround()
@@ -176,8 +212,8 @@ namespace RogueEssence.Menu
             base.Draw(spriteBatch);
 
             //draw other windows
-            titleMenu.Draw(spriteBatch);
-            summaryMenu.Draw(spriteBatch);
+            TitleMenu.Draw(spriteBatch);
+            SummaryMenu.Draw(spriteBatch);
         }
 
 

--- a/RogueEssence/Menu/MenuManager.cs
+++ b/RogueEssence/Menu/MenuManager.cs
@@ -32,6 +32,7 @@ namespace RogueEssence.Menu
             menus = new List<IInteractable>();
         }
 
+        //Open a menu
         public void AddMenu(IInteractable menu, bool stackOn)
         {
             if (menuModeDepth == 0)
@@ -53,6 +54,7 @@ namespace RogueEssence.Menu
             menus.Add(menu);
         }
 
+        //Close a menu
         public void RemoveMenu()
         {
             if (menuModeDepth == 0)

--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -1,21 +1,26 @@
 ﻿using System.Collections.Generic;
+using RogueEssence.Script;
 using RogueElements;
 
 namespace RogueEssence.Menu
 {
     public class OthersMenu : TitledStripMenu
     {
+        
+        public List<MenuTextChoice> Choices { get; set; }
 
         public OthersMenu()
         {
-            List<MenuTextChoice> choices = new List<MenuTextChoice>();
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
-
-            Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_OTHERS_TITLE"), choices.ToArray(), 0);
+            Choices = new List<MenuTextChoice>();
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
         }
 
+        public override void InitMenu()
+        {
+            Initialize(new Loc(16, 16), CalculateChoiceLength(Choices, 72), Text.FormatKey("MENU_OTHERS_TITLE"), Choices.ToArray(), 0);
+        }
     }
 }

--- a/RogueEssence/Menu/Others/ReplayMenu.cs
+++ b/RogueEssence/Menu/Others/ReplayMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using RogueElements;
 using RogueEssence.Data;
 using RogueEssence.Dungeon;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -19,6 +20,8 @@ namespace RogueEssence.Menu
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_END"), endReplay));
 
             Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_REPLAY_TITLE"), choices.ToArray(), 0);
+            
+            LuaEngine.Instance.OnReplayMenuCreated(this);
         }
 
         private void makeQuicksave()

--- a/RogueEssence/Menu/Others/ReplayMenu.cs
+++ b/RogueEssence/Menu/Others/ReplayMenu.cs
@@ -19,9 +19,9 @@ namespace RogueEssence.Menu
 
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_END"), endReplay));
 
-            Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_REPLAY_TITLE"), choices.ToArray(), 0);
-            
             LuaEngine.Instance.OnReplayMenuCreated(this);
+            
+            Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_REPLAY_TITLE"), choices.ToArray(), 0);
         }
 
         private void makeQuicksave()

--- a/RogueEssence/Menu/Others/RestMenu.cs
+++ b/RogueEssence/Menu/Others/RestMenu.cs
@@ -19,9 +19,9 @@ namespace RogueEssence.Menu
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_SUSPEND"), SuspendAction, isRecording, isRecording ? Color.White : Color.Red));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_QUIT"), QuitAction));
 
-            Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_REST_TITLE"), choices.ToArray(), 0);
-            
             LuaEngine.Instance.OnRestMenuCreated(this);
+            
+            Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_REST_TITLE"), choices.ToArray(), 0);
         }
 
         private void SuspendAction()

--- a/RogueEssence/Menu/Others/RestMenu.cs
+++ b/RogueEssence/Menu/Others/RestMenu.cs
@@ -5,6 +5,7 @@ using RogueEssence.Data;
 using RogueEssence.Dungeon;
 using RogueEssence.Ground;
 using Microsoft.Xna.Framework;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -19,6 +20,8 @@ namespace RogueEssence.Menu
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_QUIT"), QuitAction));
 
             Initialize(new Loc(16, 16), CalculateChoiceLength(choices, 72), Text.FormatKey("MENU_REST_TITLE"), choices.ToArray(), 0);
+            
+            LuaEngine.Instance.OnRestMenuCreated(this);
         }
 
         private void SuspendAction()

--- a/RogueEssence/Menu/ReplaceableMenu.cs
+++ b/RogueEssence/Menu/ReplaceableMenu.cs
@@ -1,0 +1,9 @@
+﻿namespace RogueEssence.Menu;
+
+/**
+ * A wrapper class solely designed to contain an InteractableMenu, which can be substituted as needed
+ */
+public class ReplaceableMenu
+{
+    public InteractableMenu menu { get; set; }
+}

--- a/RogueEssence/Menu/Team/TacticsMenu.cs
+++ b/RogueEssence/Menu/Team/TacticsMenu.cs
@@ -68,9 +68,9 @@ namespace RogueEssence.Menu
             }
             totalChoices[0] = new MenuSetting(Text.FormatKey("MENU_TACTICS_EVERYONE"), 88, 72, allChoices, groupTactic, confirmAction);
 
-            Initialize(new Loc(16, 16), 224, Text.FormatKey("MENU_TACTICS_TITLE"), totalChoices);
-
             LuaEngine.Instance.OnTacticsMenuCreated(this);
+            
+            Initialize(new Loc(16, 16), 224, Text.FormatKey("MENU_TACTICS_TITLE"), totalChoices);
         }
 
 

--- a/RogueEssence/Menu/Team/TacticsMenu.cs
+++ b/RogueEssence/Menu/Team/TacticsMenu.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using RogueEssence.Dungeon;
 using RogueEssence.Data;
 using RogueEssence.Ground;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -68,6 +69,8 @@ namespace RogueEssence.Menu
             totalChoices[0] = new MenuSetting(Text.FormatKey("MENU_TACTICS_EVERYONE"), 88, 72, allChoices, groupTactic, confirmAction);
 
             Initialize(new Loc(16, 16), 224, Text.FormatKey("MENU_TACTICS_TITLE"), totalChoices);
+
+            LuaEngine.Instance.OnTacticsMenuCreated(this);
         }
 
 

--- a/RogueEssence/Menu/Team/TeamMenu.cs
+++ b/RogueEssence/Menu/Team/TeamMenu.cs
@@ -76,10 +76,10 @@ namespace RogueEssence.Menu
 
             if (teamSlot == -1)
                 teamSlot = Math.Min(Math.Max(0, defaultChoice), team.Count-1);
-
-            Initialize(new Loc(16, 16), menuWidth, Text.FormatKey("MENU_TEAM_TITLE"), team.ToArray(), teamSlot);
             
             LuaEngine.Instance.OnTeamMenuCreated(this);
+            
+            Initialize(new Loc(16, 16), menuWidth, Text.FormatKey("MENU_TEAM_TITLE"), team.ToArray(), teamSlot);
         }
 
 

--- a/RogueEssence/Menu/Team/TeamMenu.cs
+++ b/RogueEssence/Menu/Team/TeamMenu.cs
@@ -7,6 +7,7 @@ using RogueElements;
 using RogueEssence.Data;
 using RogueEssence.Ground;
 using System;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -77,6 +78,8 @@ namespace RogueEssence.Menu
                 teamSlot = Math.Min(Math.Max(0, defaultChoice), team.Count-1);
 
             Initialize(new Loc(16, 16), menuWidth, Text.FormatKey("MENU_TEAM_TITLE"), team.ToArray(), teamSlot);
+            
+            LuaEngine.Instance.OnTeamMenuCreated(this);
         }
 
 


### PR DESCRIPTION
-Allow for modifying or replacing the main menu in a ground or dungeon.
-Allows for modifying the "others" submenu in a ground or dungeon
-Exposes a number of menus for scripts