### PR TITLE
Adding text wrapping to the DataGrid in the Editor's Ground Map String Tab

### DIFF
--- a/RogueEssence.Editor.Avalonia/Views/GroundEditForm/GroundTabStrings.axaml
+++ b/RogueEssence.Editor.Avalonia/Views/GroundEditForm/GroundTabStrings.axaml
@@ -8,28 +8,49 @@
   <Design.DataContext>
     <vm:GroundTabStringsViewModel/>
   </Design.DataContext>
+
+
   <Grid Margin="4" >
+
     <Grid.RowDefinitions>
-      <RowDefinition Height="20"/>
+      <RowDefinition Height="Auto"/>
       <RowDefinition/>
       <RowDefinition Height="34"/>
     </Grid.RowDefinitions>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition/>
-      <ColumnDefinition/>
-      <ColumnDefinition/>
-      <ColumnDefinition/>
-      <ColumnDefinition/>
-    </Grid.ColumnDefinitions>
-    <TextBlock Margin="4" VerticalAlignment="Bottom" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="5">Add, edit, or remove localized strings to be used by scripts on the map.</TextBlock>
-    <DataGrid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" Items="{Binding MapStrings}" SelectedIndex="{Binding CurrentString, Mode=TwoWay}" CanUserResizeColumns="True">
+
+    <TextBlock Margin="4" VerticalAlignment="Bottom" Grid.Row="0" TextWrapping="Wrap">Add, edit, or remove localized strings to be used by scripts on the map.</TextBlock>
+
+    <DataGrid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" Items="{Binding MapStrings}" SelectedIndex="{Binding CurrentString, Mode=TwoWay}"
+              CanUserResizeColumns="True" HorizontalScrollBarVisibility="Disabled">
+
+      <DataGrid.Styles>
+        <Style Selector="TextBlock">
+          <Setter Property="TextWrapping" Value="WrapWithOverflow" />
+        </Style>
+        <Style Selector="TextBox">
+          <Setter Property="TextWrapping" Value="Wrap" />
+          <Setter Property="AcceptsReturn" Value="True" />
+        </Style>
+      </DataGrid.Styles>
+
       <DataGrid.Columns>
-        <DataGridTextColumn Header="Key" Binding="{Binding Key}"/>
-        <DataGridTextColumn Header="Comment" Binding="{Binding Comment}"/>
-        <DataGridTextColumn Header="String" Binding="{Binding String}" />
+        <DataGridTextColumn Header="Key" Binding="{Binding Key}" Width="1*"/>
+        <DataGridTextColumn Header="Comment" Binding="{Binding Comment}" Width="2*"/>
+        <DataGridTextColumn Header="String" Binding="{Binding String}" Width="3*"/>
       </DataGrid.Columns>
     </DataGrid>
-    <Button Command="{Binding btnAddString_Click}" Margin="4" Grid.Row="2" Grid.Column="0">Add String</Button>
-    <Button Command="{Binding btnDeleteString_Click}" Margin="4" Grid.Row="2" Grid.Column="1">Delete String</Button>
+
+    <Grid Margin="0" Grid.Row="2" >
+
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition/>
+        <ColumnDefinition/>
+      </Grid.ColumnDefinitions>
+
+      <Button Command="{Binding btnAddString_Click}" Margin="0,4,4,4" Grid.Column="0">Add String</Button>
+      <Button Command="{Binding btnDeleteString_Click}" Margin="4,4,0,4" Grid.Column="1">Delete String</Button>
+
+    </Grid>
+
   </Grid>
 </UserControl>


### PR DESCRIPTION
This PR makes everything in the Ground Map string tab editor use text wrapping. The primary benefit here is now users can write longer dialog in the data grid cells while being able to see all the text.