### PR TITLE
Allow saving on all forms of closing except cancel

### DIFF
--- a/RogueEssence.Editor.Avalonia/DataEditor/DataEditForm.axaml.cs
+++ b/RogueEssence.Editor.Avalonia/DataEditor/DataEditForm.axaml.cs
@@ -19,6 +19,8 @@ namespace RogueEssence.Dev.Views
     {
         public delegate Task<bool> OKEvent();
         public OKEvent SelectedOKEvent;
+
+        public bool Cancel;
         //public event Action SelectedCancelEvent;
 
         public StackPanel ControlPanel { get; }
@@ -61,12 +63,15 @@ namespace RogueEssence.Dev.Views
             this.Width = this.Width + 10;
         }
 
-        public virtual void Window_Closing(object sender, CancelEventArgs e)
+        public virtual async void Window_Closing(object sender, CancelEventArgs e)
         {
             if (Design.IsDesignMode)
                 return;
             
             CloseChildren();
+            
+            if(!Cancel)
+                await SaveChildren();
         }
 
         public async void btnOK_Click(object sender, RoutedEventArgs e)
@@ -81,6 +86,7 @@ namespace RogueEssence.Dev.Views
         public void btnCancel_Click(object sender, RoutedEventArgs e)
         {
             //SelectedCancelEvent?.Invoke();
+            Cancel = true;
             Close();
         }
 

--- a/RogueEssence.Editor.Avalonia/DataEditor/DataEditRootForm.axaml.cs
+++ b/RogueEssence.Editor.Avalonia/DataEditor/DataEditRootForm.axaml.cs
@@ -27,7 +27,7 @@ namespace RogueEssence.Dev.Views
             await SaveChildren();
         }
 
-        public override void Window_Closing(object sender, CancelEventArgs e)
+        public override async void Window_Closing(object sender, CancelEventArgs e)
         {
             base.Window_Closing(sender, e);
 

--- a/RogueEssence.Editor.Avalonia/DataEditor/ParentForm.cs
+++ b/RogueEssence.Editor.Avalonia/DataEditor/ParentForm.cs
@@ -17,6 +17,8 @@ namespace RogueEssence.Dev.Views
     public class ParentForm : Window
     {
         protected List<Window> children;
+        protected bool OK;
+        protected bool Cancel;
 
         public ParentForm()
         {
@@ -32,10 +34,25 @@ namespace RogueEssence.Dev.Views
             };
         }
 
+        public void FocusChildren()
+        {
+            for (int ii = children.Count - 1; ii >= 0; ii--)
+                children[ii].Activate();
+        }
+
         public void CloseChildren()
         {
             for (int ii = children.Count - 1; ii >= 0; ii--)
+            {
+                DataEditForm dataEditor = children[ii] as DataEditForm;
+                if (dataEditor != null)
+                {
+                    dataEditor.OK = this.OK;
+                    dataEditor.Cancel = this.Cancel;
+                }
                 children[ii].Close();
+            }
+                
         }
 
     }


### PR DESCRIPTION
-Clicking on the OK button will trigger a save all, regardless of which window you clicked OK on.
-Clicking on the X button in the top right will also trigger a save all, as it is common enough to accidently click on the X button if you just want to save your changes.
-Clicking on the Cancel button will reverse any changes you made automatically.
-Doesn't matter which window you click OK, X, or Cancel at- the behavior is propagated down to all child windows that are being closed.