### PR TITLE
Destructible tiles

### DIFF
--- a/RogueEssence/Data/TileData.cs
+++ b/RogueEssence/Data/TileData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using RogueEssence.Dungeon;
 using RogueEssence.Dev;
 using RogueEssence.Content;
@@ -24,8 +25,7 @@ namespace RogueEssence.Data
             Trap,
             Switch,
             Blocker,
-            Unlockable,
-            Destructible
+            Unlockable
         }
 
         public LocalText Name { get; set; }
@@ -55,21 +55,31 @@ namespace RogueEssence.Data
         public TriggerType StepType;
         public Loc MinimapIcon;
         public Color MinimapColor;
-
-        /// <summary>
-        /// Element for the tile- anything supereffective against this type will destroy it.  If this is none, any attack will destroy it.  Only used if TriggerType is Destructible.
-        /// </summary>
-        [JsonConverter(typeof(ElementConverter))]
-        [Dev.DataType(0, DataManager.DataType.Element, false)]
-        public string TileElement;
         
         /// <summary>
-        /// If true, only attacks of TileElement will destroy the tile, rather than supereffective attacks.  Only used if TriggerType is Destructible.
+        /// Allows the tile to be destroyed by certain attacks.
         /// </summary>
-        public bool SpecificElementDestroysTile;
+        public bool Destructible;
+
+        /// <summary>
+        /// Any supereffective move used against this tile will destroy it.  If this is none, any attack will destroy it.  Only used if Destructible is true.
+        /// </summary>
+        [JsonConverter(typeof(ElementListConverter))]
+        [Dev.DataType(0, DataManager.DataType.Element, false)]
+        public List<string> EffectiveElements;
+        
+        /// <summary>
+        /// The minimum damage needed to destroy the tile.  Only used if Destructible is true.
+        /// </summary>
+        public int PowerNeededToDestroy;
 
         public PriorityList<SingleCharEvent> LandedOnTiles;
         public PriorityList<SingleCharEvent> InteractWithTiles;
+        
+        /// <summary>
+        /// Triggers right before the tile is destroyed.  Only used if Destructible is true.
+        /// </summary>
+        public PriorityList<SingleCharEvent> OnTileDestroyed;
 
         public TileData()
         {
@@ -77,8 +87,10 @@ namespace RogueEssence.Data
             Desc = new LocalText();
             Comment = "";
             Anim = new ObjAnimData();
+            EffectiveElements = new List<string>();
             LandedOnTiles = new PriorityList<SingleCharEvent>();
             InteractWithTiles = new PriorityList<SingleCharEvent>();
+            OnTileDestroyed = new PriorityList<SingleCharEvent>();
         }
         
         public string GetColoredName()

--- a/RogueEssence/Data/TileData.cs
+++ b/RogueEssence/Data/TileData.cs
@@ -25,7 +25,8 @@ namespace RogueEssence.Data
             Trap,
             Switch,
             Blocker,
-            Unlockable
+            Unlockable,
+            Object
         }
 
         public LocalText Name { get; set; }
@@ -92,7 +93,6 @@ namespace RogueEssence.Data
             InteractWithTiles = new PriorityList<SingleCharEvent>();
             OnTileDestroyed = new PriorityList<SingleCharEvent>();
         }
-        
         public string GetColoredName()
         {
             return String.Format("[color=#00FF00]{0}[color]", Name.ToLocal());

--- a/RogueEssence/Data/TileData.cs
+++ b/RogueEssence/Data/TileData.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using RogueEssence.Dungeon;
+using RogueEssence.Dev;
 using RogueEssence.Content;
 using RogueElements;
+using Newtonsoft.Json;
 using Microsoft.Xna.Framework;
 
 namespace RogueEssence.Data
@@ -22,7 +24,8 @@ namespace RogueEssence.Data
             Trap,
             Switch,
             Blocker,
-            Unlockable
+            Unlockable,
+            Destructible
         }
 
         public LocalText Name { get; set; }
@@ -53,6 +56,18 @@ namespace RogueEssence.Data
         public Loc MinimapIcon;
         public Color MinimapColor;
 
+        /// <summary>
+        /// Element for the tile- anything supereffective against this type will destroy it.  If this is none, any attack will destroy it.  Only used if TriggerType is Destructible.
+        /// </summary>
+        [JsonConverter(typeof(ElementConverter))]
+        [Dev.DataType(0, DataManager.DataType.Element, false)]
+        public string TileElement;
+        
+        /// <summary>
+        /// If true, only attacks of TileElement will destroy the tile, rather than supereffective attacks.  Only used if TriggerType is Destructible.
+        /// </summary>
+        public bool SpecificElementDestroysTile;
+
         public PriorityList<SingleCharEvent> LandedOnTiles;
         public PriorityList<SingleCharEvent> InteractWithTiles;
 
@@ -65,8 +80,7 @@ namespace RogueEssence.Data
             LandedOnTiles = new PriorityList<SingleCharEvent>();
             InteractWithTiles = new PriorityList<SingleCharEvent>();
         }
-
-
+        
         public string GetColoredName()
         {
             return String.Format("[color=#00FF00]{0}[color]", Name.ToLocal());

--- a/RogueEssence/Dungeon/BaseDungeonScene.cs
+++ b/RogueEssence/Dungeon/BaseDungeonScene.cs
@@ -237,9 +237,22 @@ namespace RogueEssence.Dungeon
             {
                 foreach(Loc viewLoc in IterateRelevantDraw(wrapped, wrapSize, item))
                 {
-                    TerrainTile tile = ZoneManager.Instance.CurrentMap.Tiles[item.TileLoc.X][item.TileLoc.Y].Data;
+                    Tile rootTile = ZoneManager.Instance.CurrentMap.Tiles[item.TileLoc.X][item.TileLoc.Y];
+                    TerrainTile tile = rootTile.Data;
                     TerrainData terrain = tile.GetData();
-                    if (terrain.BlockType == TerrainData.Mobility.Impassable || terrain.BlockType == TerrainData.Mobility.Block)
+
+                    //Object tiles should hide items beneath them
+                    bool hiddenBehindObject = false;
+                    if (!String.IsNullOrEmpty(rootTile.Effect.ID))
+                    {
+                        TileData effect = DataManager.Instance.GetTile(rootTile.Effect.ID);
+                        if (effect.StepType == TileData.TriggerType.Object)
+                        {
+                            hiddenBehindObject = true;
+                        }
+                    }
+                    
+                    if (terrain.BlockType == TerrainData.Mobility.Impassable || terrain.BlockType == TerrainData.Mobility.Block || hiddenBehindObject)
                     {
                         if (showHiddenItem)
                             item.Draw(spriteBatch, viewLoc, Color.White * 0.7f);

--- a/RogueEssence/Dungeon/Characters/CharAction.cs
+++ b/RogueEssence/Dungeon/Characters/CharAction.cs
@@ -802,7 +802,7 @@ namespace RogueEssence.Dungeon
             for (int ii = 0; ii < modRange; ii++)
             {
                 targetLoc += addLoc;
-                if (ZoneManager.Instance.CurrentMap.TileBlocked(targetLoc, true))
+                if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(targetLoc, true))
                     break;
             }
             return targetLoc + HitOffset;
@@ -1320,7 +1320,7 @@ namespace RogueEssence.Dungeon
             for (int ii = 0; ii < modRange; ii++)
             {
                 targetLoc += addLoc;
-                if (ZoneManager.Instance.CurrentMap.TileBlocked(targetLoc, true))
+                if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(targetLoc, true))
                     break;
             }
             return targetLoc;
@@ -1415,14 +1415,14 @@ namespace RogueEssence.Dungeon
                         }
 
 
-                        if (ZoneManager.Instance.CurrentMap.TileBlocked(leftLoc, true))
+                        if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(leftLoc, true))
                             sideL[side] = false;
-                        if (ZoneManager.Instance.CurrentMap.TileBlocked(rightLoc, true))
+                        if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(rightLoc, true))
                             sideR[side] = false;
                     }
                 }
 
-                if (ZoneManager.Instance.CurrentMap.TileBlocked(targetLoc, true))
+                if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(targetLoc, true))
                     sideM = false;
             }
             return null;

--- a/RogueEssence/Dungeon/Characters/Hitbox.cs
+++ b/RogueEssence/Dungeon/Characters/Hitbox.cs
@@ -457,7 +457,7 @@ namespace RogueEssence.Dungeon
             tilesToHit.Enqueue(calculateTimeToHit(Origin) + delay, Origin);
 
             Loc backup = Origin;
-            if (MaxRadius > 0 && ZoneManager.Instance.CurrentMap.TileBlocked(Origin, true))
+            if (MaxRadius > 0 && ZoneManager.Instance.CurrentMap.TileAttackBlocked(Origin, true))
                 backup += Dir.Reverse().GetLoc();
 
             Grid.FloodFill(new Rect(Origin - new Loc(MaxRadius), new Loc(MaxRadius * 2 + 1)),
@@ -467,7 +467,7 @@ namespace RogueEssence.Dungeon
                     return true;
                 if (!IsInSquareHitbox(testLoc, Origin, MaxRadius, HitArea, Dir))
                     return true;
-                if (ZoneManager.Instance.CurrentMap.TileBlocked(testLoc, true))
+                if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(testLoc, true))
                     return true;
 
                 return false;

--- a/RogueEssence/Dungeon/DSceneAction.cs
+++ b/RogueEssence/Dungeon/DSceneAction.cs
@@ -684,7 +684,7 @@ namespace RogueEssence.Dungeon
                 return true;
 
             TerrainData.Mobility mobility = TerrainData.Mobility.Lava | TerrainData.Mobility.Water | TerrainData.Mobility.Abyss;
-            if (ZoneManager.Instance.CurrentMap.TileBlocked(tile, mobility))
+            if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(tile, mobility))
                 return true;
             else
                 return false;

--- a/RogueEssence/Dungeon/DSceneMap.cs
+++ b/RogueEssence/Dungeon/DSceneMap.cs
@@ -560,7 +560,7 @@ namespace RogueEssence.Dungeon
                 if (tile != null && !String.IsNullOrEmpty(tile.Effect.ID))
                 {
                     TileData entry = DataManager.Instance.GetTile(tile.Effect.ID);
-                    if (entry.StepType == TileData.TriggerType.Blocker || entry.StepType == TileData.TriggerType.Unlockable)
+                    if (entry.StepType == TileData.TriggerType.Blocker || entry.StepType == TileData.TriggerType.Unlockable || entry.StepType == TileData.TriggerType.Object)
                     {
                         yield return CoroutineManager.Instance.StartCoroutine(tile.Effect.LandedOnTile(character));
                         yield return CoroutineManager.Instance.StartCoroutine(ActivateTraps(character));
@@ -1446,7 +1446,7 @@ namespace RogueEssence.Dungeon
                 for (int ii = 0; ii < range; ii++)
                 {
                     Loc nextLoc = endLoc + dir.GetLoc();
-                    if (ZoneManager.Instance.CurrentMap.TileBlocked(nextLoc, true))
+                    if (ZoneManager.Instance.CurrentMap.TileAttackBlocked(nextLoc, true))
                         break;
                     endLoc = nextLoc;
                 }

--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -1049,8 +1049,21 @@ namespace RogueEssence.Dungeon
             {
                 foreach (Loc viewLoc in IterateRelevantDraw(wrapped, wrapSize, item))
                 {
-                    TerrainData terrain = ZoneManager.Instance.CurrentMap.Tiles[item.TileLoc.X][item.TileLoc.Y].Data.GetData();
-                    if (terrain.BlockType == TerrainData.Mobility.Impassable || terrain.BlockType == TerrainData.Mobility.Block)
+                    Tile rootTile = ZoneManager.Instance.CurrentMap.Tiles[item.TileLoc.X][item.TileLoc.Y];
+                    TerrainData terrain = rootTile.Data.GetData();
+                    
+                    //Object tiles should hide items beneath them
+                    bool hiddenBehindObject = false;
+                    if (!String.IsNullOrEmpty(rootTile.Effect.ID))
+                    {
+                        TileData effect = DataManager.Instance.GetTile(rootTile.Effect.ID);
+                        if (effect.StepType == TileData.TriggerType.Object)
+                        {
+                            hiddenBehindObject = true;
+                        }
+                    }
+                    
+                    if (terrain.BlockType == TerrainData.Mobility.Impassable || terrain.BlockType == TerrainData.Mobility.Block || hiddenBehindObject)
                     {
                         if (showHiddenItem)
                             item.Draw(spriteBatch, viewLoc, Color.White * 0.5f);

--- a/RogueEssence/Dungeon/GameEffects/BattleContext.cs
+++ b/RogueEssence/Dungeon/GameEffects/BattleContext.cs
@@ -232,6 +232,28 @@ namespace RogueEssence.Dungeon
                 actionContext.Target = charTarget;
                 yield return CoroutineManager.Instance.StartCoroutine(DungeonScene.Instance.HitTarget(actionContext, charTarget));//hit the character
             }
+
+            Tile tile = ZoneManager.Instance.CurrentMap.GetTile(actionContext.TargetTile);
+            if (!String.IsNullOrEmpty(tile.Effect.ID))
+            {
+                TileData entry = DataManager.Instance.GetTile(tile.Effect.GetID());
+                if (entry != null && entry.Destructible && actionContext.ActionType == BattleActionType.Skill)
+                {
+                    BattleData data = actionContext.Data;
+                    if (data != null)
+                    {
+                        BasePowerState powerState = data.SkillStates.GetWithDefault<BasePowerState>();
+                        //Check if the attack is from the specific element or from no element, and deals enough damage
+                        if ((entry.EffectiveElements.Contains(data.Element) || entry.EffectiveElements.Count == 0)
+                            && powerState != null && powerState.Power >= entry.PowerNeededToDestroy)
+                        {
+                            yield return CoroutineManager.Instance.StartCoroutine(tile.Effect.OnTileDestroyed(charTarget));
+                            tile.Effect = new EffectTile(tile.Effect.TileLoc);
+                        }
+                    }
+                }
+            }
+            
             //do thing to tile
             yield return CoroutineManager.Instance.StartCoroutine(actionContext.User.HitTile(actionContext));
         }
@@ -241,6 +263,28 @@ namespace RogueEssence.Dungeon
             BattleContext actionContext = new BattleContext(this, false);
             actionContext.TargetTile = loc;
 
+            Tile tile = ZoneManager.Instance.CurrentMap.GetTile(actionContext.TargetTile);
+            if (!String.IsNullOrEmpty(tile.Effect.ID))
+            {
+                TileData entry = DataManager.Instance.GetTile(tile.Effect.GetID());
+                if (entry != null && entry.Destructible && actionContext.ActionType == BattleActionType.Skill)
+                {
+                    BattleData data = actionContext.Data;
+                    Character charTarget = actionContext.User;
+                    if (data != null && charTarget != null)
+                    {
+                        BasePowerState powerState = data.SkillStates.GetWithDefault<BasePowerState>();
+                        //Check if the attack is from the specific element or from no element, and deals enough damage
+                        if ((entry.EffectiveElements.Contains(data.Element) || entry.EffectiveElements.Count == 0)
+                            && powerState != null && powerState.Power >= entry.PowerNeededToDestroy)
+                        {
+                            yield return CoroutineManager.Instance.StartCoroutine(tile.Effect.OnTileDestroyed(charTarget));
+                            tile.Effect = new EffectTile(tile.Effect.TileLoc);
+                        }
+                    }
+                }
+            }
+            
             //do thing to tile
             yield return CoroutineManager.Instance.StartCoroutine(actionContext.User.HitTile(actionContext));
         }

--- a/RogueEssence/Dungeon/Maps/BaseMap.cs
+++ b/RogueEssence/Dungeon/Maps/BaseMap.cs
@@ -120,6 +120,42 @@ namespace RogueEssence.Dungeon
             }
             return -1;
         }
+        
+        public bool TileAttackBlocked(Loc loc)
+        {
+            return TileAttackBlocked(loc, false);
+        }
+        
+        public bool TileAttackBlocked(Loc loc, bool inclusive)
+        {
+            return TileAttackBlocked(loc, inclusive, false);
+        }
+
+        public bool TileAttackBlocked(Loc loc, bool inclusive, bool diagonal)
+        {
+            return TileAttackBlocked(loc, inclusive ? TerrainData.Mobility.All : TerrainData.Mobility.Passable, diagonal);
+        }
+
+        public bool TileAttackBlocked(Loc loc, TerrainData.Mobility mobility)
+        {
+            return TileAttackBlocked(loc, mobility, false);
+        }
+
+        public bool TileAttackBlocked(Loc loc, TerrainData.Mobility mobility, bool diagonal)
+        {
+            Tile tile = Tiles[loc.X][loc.Y];
+            if (!String.IsNullOrEmpty(tile.Effect.ID))
+            {
+                TileData effect = DataManager.Instance.GetTile(tile.Effect.ID);
+                if (effect.StepType == TileData.TriggerType.Object)
+                {
+                    //Objects should allow attacks through but not movement
+                    return false;
+                }
+            }
+
+            return TileBlocked(loc, mobility, diagonal);
+        }
 
         public bool TileBlocked(Loc loc)
         {
@@ -185,7 +221,7 @@ namespace RogueEssence.Dungeon
             //doesn't apply here; for now, assume all effects block diagonal if they block at all
             //if (diagonal && !effect.BlockDiagonal)
             //    return false;
-            if (effect.StepType == TileData.TriggerType.Unlockable || effect.StepType == TileData.TriggerType.Blocker)
+            if (effect.StepType == TileData.TriggerType.Unlockable || effect.StepType == TileData.TriggerType.Blocker || effect.StepType == TileData.TriggerType.Object)
                 return true;
 
             return false;

--- a/RogueEssence/Dungeon/Tiles/EffectTile.cs
+++ b/RogueEssence/Dungeon/Tiles/EffectTile.cs
@@ -120,6 +120,23 @@ namespace RogueEssence.Dungeon
                     yield break;
             }
         }
+        
+        public IEnumerator<YieldInstruction> OnTileDestroyed(Character character)
+        {
+            SingleCharContext context = new SingleCharContext(character);
+            // should the context be extended to the caller?
+            DungeonScene.EventEnqueueFunction<SingleCharEvent> function = (StablePriorityQueue<GameEventPriority, EventQueueElement<SingleCharEvent>> queue, Priority maxPriority, ref Priority nextPriority) =>
+            {
+                TileData entry = DataManager.Instance.GetTile(ID);
+                AddEventsToQueue<SingleCharEvent>(queue, maxPriority, ref nextPriority, entry.OnTileDestroyed, context.User);
+            };
+            foreach (EventQueueElement<SingleCharEvent> effect in DungeonScene.IterateEvents<SingleCharEvent>(function))
+            {
+                yield return CoroutineManager.Instance.StartCoroutine(effect.Event.Apply(effect.Owner, effect.OwnerChar, context));
+                if (context.CancelState.Cancel)
+                    yield break;
+            }
+        }
 
         public void DrawDebug(SpriteBatch spriteBatch, Loc offset) { }
         public void Draw(SpriteBatch spriteBatch, Loc offset)


### PR DESCRIPTION
-Add the ability for tiles to be instantly destroyed with Moves of certain types and power.  Effects can be spawned when the tile is destroyed this way.
-Add an "Object" category for tiles.  Objects cannot be passed through but can be attacked through, and items inside of an object are hidden until the object is destroyed.