### PR TITLE
allow custom ground actions

### DIFF
--- a/RogueEssence/Data/ItemData.cs
+++ b/RogueEssence/Data/ItemData.cs
@@ -2,6 +2,7 @@
 using RogueEssence.Dev;
 using RogueEssence.Dungeon;
 using System.Collections.Generic;
+using RogueEssence.Ground;
 
 namespace RogueEssence.Data
 {
@@ -87,7 +88,12 @@ namespace RogueEssence.Data
         /// They are potentially checked against in a select number of battle events.
         /// </summary>
         public StateCollection<ItemState> ItemStates;
-
+        
+        /// <summary>
+        /// List of ground actions that can be used with that item.
+        /// </summary>
+        public List<GroundItemEvent> GroundUseActions;
+        
         /// <summary>
         /// The hitbox of the attack that comes out when the item is used.
         /// </summary>
@@ -135,6 +141,7 @@ namespace RogueEssence.Data
             Comment = "";
 
             ItemStates = new StateCollection<ItemState>();
+            GroundUseActions = new List<GroundItemEvent>();
 
             UseAction = new AttackAction();
             Explosion = new ExplosionData();

--- a/RogueEssence/Ground/GSceneZone.cs
+++ b/RogueEssence/Ground/GSceneZone.cs
@@ -159,9 +159,10 @@ namespace RogueEssence.Ground
                     {
                         //[0] = item slot to use (-1 for held item, -2 for the ground item)
                         //[1] = who to use it on (-1 for the user)
+                        //[2] = idx for the GroundUseActions list otherwise -1
                         //others: which slot to delete,
                         //which intrinsic to have, which team member/item to send in, etc.
-                        yield return CoroutineManager.Instance.StartCoroutine(ProcessUseItem(character, action[0], action[1]));
+                        yield return CoroutineManager.Instance.StartCoroutine(ProcessUseItem(character, action[0], action[1], action[2]));
                         break;
                     }
                 case GameAction.ActionType.ShiftTeam:

--- a/RogueEssence/Ground/GroundContext.cs
+++ b/RogueEssence/Ground/GroundContext.cs
@@ -1,0 +1,19 @@
+using RogueEssence.Dungeon;
+
+namespace RogueEssence.Ground
+{
+    public class GroundContext : GameContext
+    {
+        public GroundChar Owner;
+
+        public InvItem Item;
+
+        public GroundContext(InvItem item, GroundChar owner, Character target)
+        {
+            Item = item;
+            Owner = owner;
+            User = target;
+        }
+
+    }
+}

--- a/RogueEssence/Ground/GroundItemEvent.cs
+++ b/RogueEssence/Ground/GroundItemEvent.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLua;
+using RogueEssence.Data;
+using RogueEssence.Dev;
+using RogueEssence.Dungeon;
+using RogueEssence.Menu;
+using RogueEssence.Script;
+
+namespace RogueEssence.Ground
+{
+    public enum SelectionType
+    {
+        /// <summary>
+        /// apply to user
+        /// </summary>
+        Self,
+        /// <summary>
+        /// apply to other party members
+        /// </summary>
+        Others,
+    }
+    
+    public abstract class GroundItemEvent : GameEvent
+    {
+        public ItemData.UseType GroundUsageType;
+        public SelectionType Selection;
+        public abstract IEnumerator<YieldInstruction> Apply(GroundContext context);
+    }
+    
+    [Serializable]
+    public class ScriptItemEvent : GroundItemEvent
+    {
+        [Dev.Sanitize(0)]
+        public string Script;
+        [Dev.Multiline(0)]
+        public string ArgTable;
+
+        public ScriptItemEvent() { Script = ""; ArgTable = "{}"; }
+        public ScriptItemEvent(string script) { Script = script; ArgTable = "{}"; }
+        public ScriptItemEvent(string script, string argTable) { Script = script; ArgTable = argTable; }
+        protected ScriptItemEvent(ScriptItemEvent other)
+        {
+            Script = other.Script;
+            ArgTable = other.ArgTable;
+        }
+        public override GameEvent Clone() { return new ScriptItemEvent(this); }
+
+        public override IEnumerator<YieldInstruction> Apply(GroundContext context)
+        {
+            LuaTable args = LuaEngine.Instance.RunString("return " + ArgTable).First() as LuaTable;
+            object[] parameters = new object[] { context, args };
+            string name = "GROUND_ITEM_EVENT_SCRIPT." + Script;
+            LuaFunction func_iter = LuaEngine.Instance.CreateCoroutineIterator(name, parameters);
+
+            yield return CoroutineManager.Instance.StartCoroutine(ScriptEvent.ApplyFunc(name, func_iter));
+        }
+    }
+    
+    [Serializable]
+    public class LearnItemEvent : GroundItemEvent
+    {
+        [DataType(0, DataManager.DataType.Skill, false)] 
+        public string Skill;
+        public LearnItemEvent() { Skill = ""; }
+        public LearnItemEvent(string skill) { Skill = skill; }
+        protected LearnItemEvent(LearnItemEvent other) { Skill = other.Skill; }
+
+        public override GameEvent Clone() { return new LearnItemEvent(this); }
+        public override IEnumerator<YieldInstruction> Apply(GroundContext context)
+        {
+            Character target = context.User;
+            
+            int learn = -1;
+            
+            yield return CoroutineManager.Instance.StartCoroutine(DungeonScene.TryLearnSkill(target, Skill, (int slot) => { learn = slot; }, () => { context.CancelState.Cancel = true; }));
+            if (context.CancelState.Cancel) yield break;
+            
+            yield return CoroutineManager.Instance.StartCoroutine(
+                DungeonScene.LearnSkillWithFanfare(target, Skill, learn));
+        }
+    }
+}

--- a/RogueEssence/Menu/Items/ItemChosenMenu.cs
+++ b/RogueEssence/Menu/Items/ItemChosenMenu.cs
@@ -36,20 +36,55 @@ namespace RogueEssence.Menu
             else
                 invItem = DataManager.Instance.Save.ActiveTeam.GetInv(slot);
             ItemData entry = DataManager.Instance.GetItem(invItem.ID);
-
+            
             List<MenuTextChoice> choices = new List<MenuTextChoice>();
             //able to use if an item is not held, or if an item is held, but the focused character is the holder
             if (!held || holder)
             {
                 if (GameManager.Instance.CurrentScene == GroundScene.Instance)
                 {
-                    switch (entry.UsageType)
+                    for (int ii = 0; ii < entry.GroundUseActions.Count; ii++)
                     {
-                        case ItemData.UseType.Learn:
-                            {
-                                choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_TEACH"), TeachOtherAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                        int idx = ii;
+                        GroundItemEvent groundEvent = entry.GroundUseActions[idx];
+                        Action action = () => UseSelfAction(idx);
+                        
+                        
+                        switch (groundEvent.Selection)
+                        {
+                            case SelectionType.Others:
+                                action = () => UseOtherAction(idx);
                                 break;
-                            }
+                        }
+
+                        // Note the hardcode for LearnItemAction
+                        if (groundEvent is LearnItemEvent)
+                        {
+                            action = () => TeachOtherAction(idx);
+                        }
+
+                        string actionName = "";
+                        switch (groundEvent.GroundUsageType)
+                        {
+                            case ItemData.UseType.Eat:
+                                actionName = Text.FormatKey("MENU_ITEM_EAT");
+                                break;
+                            case ItemData.UseType.Drink:
+                                actionName = Text.FormatKey("MENU_ITEM_DRINK");
+                                break;
+                            case ItemData.UseType.Use:
+                                actionName = Text.FormatKey("MENU_ITEM_USE");
+                                break;
+                            case ItemData.UseType.UseOther:
+                                actionName = Text.FormatKey("MENU_ITEM_USE");
+                                break;
+                            case ItemData.UseType.Learn:
+                                actionName = Text.FormatKey("MENU_ITEM_TEACH");
+                                break;
+                        }
+                        
+                        choices.Add(new MenuTextChoice(actionName, action, !invItem.Cursed,
+                            invItem.Cursed ? Color.Red : Color.White));
                     }
                 }
                 else if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
@@ -59,30 +94,30 @@ namespace RogueEssence.Menu
                         case ItemData.UseType.Eat:
                             {
                                 if (leader && !held)
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_EAT"), UseOtherAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_EAT"), () => UseOtherAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 else
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_EAT"), UseSelfAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_EAT"), () => UseSelfAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 break;
                             }
                         case ItemData.UseType.Drink:
                             {
                                 if (leader && !held)
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_DRINK"), UseOtherAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_DRINK"), () => UseOtherAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 else
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_DRINK"), UseSelfAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_DRINK"), () => UseSelfAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 break;
                             }
                         case ItemData.UseType.Use:
                             {
-                                choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_USE"), UseSelfAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_USE"), () => UseSelfAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 break;
                             }
                         case ItemData.UseType.UseOther:
                             {
                                 if (leader && !held)
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_USE"), UseOtherAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_USE"), () => UseOtherAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 else
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_USE"), UseSelfAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_USE"), () => UseSelfAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 break;
                             }
                         case ItemData.UseType.Learn:
@@ -96,9 +131,9 @@ namespace RogueEssence.Menu
                                 }
 
                                 if (leader && !held)
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_TEACH"), TeachOtherAction, !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_TEACH"), () => TeachOtherAction(), !invItem.Cursed, invItem.Cursed ? Color.Red : Color.White));
                                 else
-                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_LEARN"), UseSelfAction, canLearn && !invItem.Cursed, (canLearn && !invItem.Cursed) ? Color.White : Color.Red));
+                                    choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_LEARN"), () => UseSelfAction(), canLearn && !invItem.Cursed, (canLearn && !invItem.Cursed) ? Color.White : Color.Red));
                                 break;
                             }
                     }
@@ -175,24 +210,24 @@ namespace RogueEssence.Menu
                 return slot;
         }
 
-        private void TeachOtherAction()
+        private void TeachOtherAction(int commandIdx = -1)
         {
             //leader gets to choose who to use item on, with previews
-            MenuManager.Instance.AddMenu(new TeachMenu(slot, held), false);
+            MenuManager.Instance.AddMenu(new TeachMenu(slot, held, commandIdx), false);
         }
-        private void UseOtherAction()
+        private void UseOtherAction(int commandIdx = -1)
         {
             //leader gets to choose who to use item on
-            MenuManager.Instance.AddMenu(new ItemTargetMenu(getItemUseSlot(), true), false);
+            MenuManager.Instance.AddMenu(new ItemTargetMenu(getItemUseSlot(), true, commandIdx), false);
         }
-
-        private void UseSelfAction()
+        
+        private void UseSelfAction(int commandIdx = -1)
         {
             //character uses the item himself
             MenuManager.Instance.ClearMenus();
-            MenuManager.Instance.EndAction = DungeonScene.Instance.ProcessPlayerInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, getItemUseSlot(), -1));
+            MenuManager.Instance.EndAction = (GameManager.Instance.CurrentScene == DungeonScene.Instance) ? DungeonScene.Instance.ProcessPlayerInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, getItemUseSlot(), -1, commandIdx)) : GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, getItemUseSlot(), -1, commandIdx));
         }
-
+        
         private void PutBackAction()
         {
             MenuManager.Instance.ClearMenus();
@@ -207,7 +242,7 @@ namespace RogueEssence.Menu
         {
             //leader gets to choose who to give the item to
             //called only when held is false
-            MenuManager.Instance.AddMenu(new ItemTargetMenu(slot, false), false);
+            MenuManager.Instance.AddMenu(new ItemTargetMenu(slot, false, -1), false);
         }
         private void HoldAction()
         {

--- a/RogueEssence/Menu/Items/ItemMenu.cs
+++ b/RogueEssence/Menu/Items/ItemMenu.cs
@@ -49,7 +49,7 @@ namespace RogueEssence.Menu
                 bool enable = !entry.CannotDrop || enableBound;
                 MenuText itemText = new MenuText(DataManager.Instance.Save.ActiveTeam.GetInv(index).GetDisplayName(), new Loc(2, 1), !enable ? Color.Red : Color.White);
                 MenuText itemPrice = new MenuText(DataManager.Instance.Save.ActiveTeam.GetInv(index).GetPriceString(), new Loc(ItemMenu.ITEM_MENU_WIDTH - 8 * 4, 1), DirV.Up, DirH.Right, !enable ? Color.Red : Color.White);
-                flatChoices.Add(new MenuElementChoice(() => { choose(index); }, true, itemText, itemPrice));
+                flatChoices.Add(new MenuElementChoice(() => { choose(index); }, enable, itemText, itemPrice));
             }
 
             int actualChoice = Math.Min(Math.Max(0, defaultChoice), flatChoices.Count - 1);

--- a/RogueEssence/Menu/Items/ItemTargetMenu.cs
+++ b/RogueEssence/Menu/Items/ItemTargetMenu.cs
@@ -17,11 +17,13 @@ namespace RogueEssence.Menu
 
         private int invSlot;
         private bool useItem;
+        private int commandIdx;
 
-        public ItemTargetMenu(int invSlot, bool useItem)
+        public ItemTargetMenu(int invSlot, bool useItem, int commandIdx)
         {
             this.invSlot = invSlot;
             this.useItem = useItem;
+            this.commandIdx = commandIdx;
 
             List<MenuTextChoice> team = new List<MenuTextChoice>();
             foreach (Character character in DataManager.Instance.Save.ActiveTeam.Players)
@@ -55,7 +57,7 @@ namespace RogueEssence.Menu
             MenuManager.Instance.ClearMenus();
             //give the item at the inv slot to the given team slot
             if (useItem)
-                MenuManager.Instance.EndAction = (GameManager.Instance.CurrentScene == DungeonScene.Instance) ? DungeonScene.Instance.ProcessPlayerInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, invSlot, choice)) : GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, invSlot, choice));
+                MenuManager.Instance.EndAction = (GameManager.Instance.CurrentScene == DungeonScene.Instance) ? DungeonScene.Instance.ProcessPlayerInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, invSlot, choice)) : GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.UseItem, Dir8.None, invSlot, choice, commandIdx));
             else
                 MenuManager.Instance.EndAction = (GameManager.Instance.CurrentScene == DungeonScene.Instance) ? DungeonScene.Instance.ProcessPlayerInput(new GameAction(GameAction.ActionType.Give, Dir8.None, invSlot, choice)) : GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.Give, Dir8.None, invSlot, choice));
         }


### PR DESCRIPTION
This PR removes the hardcode for TMs and adds ground mode use functionality for the Recall Box and Ability Capsule

Three files are added:

`GroundContext.cs` - Similar to something like BattleContext but instead carries information for the being used in which character is it being applied too

`GroundItemAction.cs` - Has the `Apply` method that takes in the GroundContext and returns an IEnumerator

`ContextStates.cs` - Several context states copied from the PMDC version in order for the Recall Box and Ability Capsule to work

ItemData now contains `List<GroundItemAction> GroundUseActions;` as a member variable for modders to add as many ground actions they want