### PR TITLE
add move_id attribute

### DIFF
--- a/RogueEssence/Dungeon/GameEffects/ItemState.cs
+++ b/RogueEssence/Dungeon/GameEffects/ItemState.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using RogueEssence.Data;
+using RogueEssence.Dev;
 
 namespace RogueEssence.Dungeon
 {
@@ -24,6 +26,7 @@ namespace RogueEssence.Dungeon
     [Serializable]
     public class ItemIDState : ItemState
     {
+        [DataType(0, DataManager.DataType.Skill, false)]
         public string ID;
         public ItemIDState() { ID = ""; }
         public ItemIDState(string idx) { ID = idx; }


### PR DESCRIPTION
Currently, `ItemIDState` only use case is for moves only. If that's the case, then this PR can be merged. Otherwise, this PR can be disregarded and closed