### PR TITLE
fix ground item usage for stacks

### DIFF
--- a/RogueEssence/Ground/GSceneMap.cs
+++ b/RogueEssence/Ground/GSceneMap.cs
@@ -46,13 +46,22 @@ namespace RogueEssence.Ground
                 if (context.CancelState.Cancel) yield break;
             }
             
-            if (invSlot < 0)
+ 
+            if (itemEntry.MaxStack > 1 && invItem.Amount > 1)
+                invItem.Amount--;
+            else if (itemEntry.MaxStack < 0)
             {
-                Character activeChar = DataManager.Instance.Save.ActiveTeam.Leader;
-                activeChar.SilentDequipItem();
+                //reusable, -1 do nothing.
             }
             else
-                DataManager.Instance.Save.ActiveTeam.RemoveFromInv(invSlot);
+            {
+                if (invSlot < 0)
+                {
+                    Character activeChar = DataManager.Instance.Save.ActiveTeam.Leader;
+                    activeChar.SilentDequipItem();
+                } else 
+                    DataManager.Instance.Save.ActiveTeam.RemoveFromInv(invSlot);
+            }
         }
 
         private IEnumerator<YieldInstruction> ProcessTrashItem(GroundChar character, int invSlot, bool held)


### PR DESCRIPTION
Allows stacks of items like Sticks to remove one at a time instead of all 9 at once