### PR TITLE
sound effect command and tags

### DIFF
--- a/RogueEssence/Lua/ScriptUI.cs
+++ b/RogueEssence/Lua/ScriptUI.cs
@@ -34,6 +34,8 @@ namespace RogueEssence.Script
         private bool m_curautoFinish = false;
         private EmoteStyle  m_curspeakerEmo = new EmoteStyle(0);
         private bool                m_curspeakerSnd = true;
+        private string m_curspeakerSe = DialogueBox.SOUND_EFFECT;
+        private int m_curspeakTime = DialogueBox.SPEAK_FRAMES;
         private IEnumerator<YieldInstruction> _m_curdialogue;
         private Rect m_curbounds = DialogueBox.DefaultBounds;
         private Loc m_curspeakerLoc = SpeakerPortrait.DefaultLoc;
@@ -131,7 +133,7 @@ namespace RogueEssence.Script
             {
                 object[] scripts = DialogueBox.CreateScripts(callbacks);
                 if (DataManager.Instance.CurrentReplay == null)
-                    m_curdialogue = MenuManager.Instance.SetDialogue(m_curspeakerID, m_curspeakerName, m_curspeakerEmo, m_curspeakerLoc, m_curspeakerSnd, () => { }, waitTime, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, new string[] { text });
+                    m_curdialogue = MenuManager.Instance.SetDialogue(m_curspeakerID, m_curspeakerName, m_curspeakerEmo, m_curspeakerLoc, m_curspeakerSnd, m_curspeakerSe, m_curspeakTime, () => { }, waitTime, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, new string[] { text });
                 else
                 {
                     if (!String.IsNullOrEmpty(m_curspeakerName))
@@ -328,6 +330,8 @@ namespace RogueEssence.Script
             m_curspeakerName = null;
             m_curspeakerEmo = new EmoteStyle(0);
             m_curspeakerSnd = keysound;
+            m_curspeakerSe = DialogueBox.SOUND_EFFECT;
+            m_curspeakTime = DialogueBox.SPEAK_FRAMES;
             m_curautoFinish = false;
             m_curcenter_h = false;
             m_curcenter_v = false;
@@ -437,6 +441,53 @@ namespace RogueEssence.Script
             m_curbounds = new Rect(x, y, width, height);
         }
 
+        /// <summary>
+        /// Sets the speaker sound effect and speak frames played in the TextDialogue functions. 
+        /// </summary>
+        /// <param name="newSe">The sound effect of the box</param>
+        /// <param name="speakTime">The amount of frames to wait between each sound effect</param>
+        /// <example>
+        /// UI:SetSe("Battle/_UNK_DUN_Water_Drop", 3)
+        /// </example>
+        public void SetSe(string newSe, int speakTime)
+        {
+            m_curspeakerSe = newSe;
+            m_curspeakTime = speakTime;
+        }
+        
+        /// <summary>
+        /// Sets the speaker sound effect played in the TextDialogue functions. 
+        /// </summary>
+        /// <param name="newSe">The sound effect of the box</param>
+        /// <example>
+        /// UI:SetSe("Menu/Unknown-3")
+        /// </example>
+        public void SetSe(string newSe)
+        {
+            m_curspeakerSe = newSe;
+        }
+
+        /// <summary>
+        /// Sets the speak frames played in the TextDialogue functions. 
+        /// </summary>
+        /// <param name="speakTime">The amount of frames to wait between each sound effect</param>
+        /// <example>
+        /// UI:SetSpeakTime(10)
+        /// </example>
+        public void SetSpeakTime(int speakTime)
+        {
+            m_curspeakTime = speakTime;
+        }
+
+        /// <summary>
+        /// Resets to the default speaker sound effect and speaker frames.
+        /// </summary>
+        public void ResetSe()
+        {
+            m_curspeakerSe = DialogueBox.SOUND_EFFECT;
+            m_curspeakTime = DialogueBox.SPEAK_FRAMES;
+        }
+        
         /// <summary>
         /// Resets the position and size of the dialogue box.
         /// </summary>
@@ -568,7 +619,7 @@ namespace RogueEssence.Script
                                                                       m_curspeakerEmo,
                                                                       m_curspeakerLoc,
                                                                       message,
-                                                                      m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc,
+                                                                      m_curspeakerSnd, m_curspeakerSe, m_curspeakTime, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc,
                                                                       () => { m_choiceresult = true; DataManager.Instance.LogUIPlay(1); },
                                                                       () => { m_choiceresult = false; DataManager.Instance.LogUIPlay(0); },
                                                                       bdefaultstono);
@@ -576,7 +627,7 @@ namespace RogueEssence.Script
                 else
                 {
                     m_curchoice = MenuManager.Instance.CreateQuestion(MonsterID.Invalid, null, new EmoteStyle(0), m_curspeakerLoc, message,
-                        m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc,
+                        m_curspeakerSnd, m_curspeakerSe, m_curspeakTime, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc,
                         () => { m_choiceresult = true; DataManager.Instance.LogUIPlay(1); },
                         () => { m_choiceresult = false; DataManager.Instance.LogUIPlay(0); }, bdefaultstono);
                 }
@@ -1407,12 +1458,12 @@ namespace RogueEssence.Script
                 if (m_curspeakerName != null)
                 {
                     m_curchoice = MenuManager.Instance.CreateMultiQuestion(m_curspeakerID, m_curspeakerName, m_curspeakerEmo, m_curspeakerLoc, 
-                            message, m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
+                            message, m_curspeakerSnd, m_curspeakerSe, m_curspeakTime, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
                 }
                 else
                 {
                     m_curchoice = MenuManager.Instance.CreateMultiQuestion(MonsterID.Invalid, null, new EmoteStyle(0), m_curspeakerLoc,
-                            message, m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
+                            message, m_curspeakerSnd, m_curspeakerSe, m_curspeakTime, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
                 }
             }
             catch (Exception e)

--- a/RogueEssence/Menu/Dialogue/ClickedDialog.cs
+++ b/RogueEssence/Menu/Dialogue/ClickedDialog.cs
@@ -11,8 +11,8 @@ namespace RogueEssence.Menu
     {
         private Action action;
 
-        public ClickedDialog(string message, bool sound, bool centerH, bool centerV, Rect bounds, object[] scripts, Action action)
-            : base(message, sound, centerH, centerV, bounds, scripts)
+        public ClickedDialog(string message, bool sound, string soundEffect, int speakTime, bool centerH, bool centerV, Rect bounds, object[] scripts, Action action)
+            : base(message, sound, soundEffect, speakTime, centerH, centerV, bounds, scripts)
         {
             this.action = action;
         }

--- a/RogueEssence/Menu/Dialogue/QuestionDialog.cs
+++ b/RogueEssence/Menu/Dialogue/QuestionDialog.cs
@@ -11,13 +11,13 @@ namespace RogueEssence.Menu
     {
         private DialogueChoiceMenu dialogueChoices;
 
-        public QuestionDialog(string message, bool sound, bool centerH, bool centerV, Rect bounds, object[] scripts, DialogueChoice[] choices, int defaultChoice, int cancelChoice, Loc menuLoc)
-            : base(message, sound, centerH, centerV, bounds, scripts)
+        public QuestionDialog(string message, bool sound, string soundEffect, int speakTime, bool centerH, bool centerV, Rect bounds, object[] scripts, DialogueChoice[] choices, int defaultChoice, int cancelChoice, Loc menuLoc)
+            : base(message, sound, soundEffect, speakTime, centerH, centerV, bounds, scripts)
         {
             dialogueChoices = new DialogueChoiceMenu(choices, defaultChoice, cancelChoice, menuLoc);
         }
 
-        public QuestionDialog(string message, bool sound, bool centerH, bool centerV, DialogueChoice[] choices, int defaultChoice, int cancelChoice) : this(message, sound, centerH, centerV, DialogueBox.DefaultBounds, new object[] {}, choices, defaultChoice, cancelChoice, new Loc(-1, -1)) {}
+        public QuestionDialog(string message, bool sound, bool centerH, bool centerV, DialogueChoice[] choices, int defaultChoice, int cancelChoice) : this(message, sound, DialogueBox.SOUND_EFFECT, DialogueBox.SPEAK_FRAMES, centerH, centerV, DialogueBox.DefaultBounds, new object[] {}, choices, defaultChoice, cancelChoice, new Loc(-1, -1)) {}
 
         public override void ProcessTextDone(InputManager input)
         {

--- a/RogueEssence/Menu/Dialogue/TimedDialog.cs
+++ b/RogueEssence/Menu/Dialogue/TimedDialog.cs
@@ -12,8 +12,8 @@ namespace RogueEssence.Menu
         protected FrameTick FinishedTextTime;
 
         
-        public TimedDialog(string message, bool sound, bool centerH, bool centerV, Rect bounds, object[] scripts, int time, Action action)
-            : base(message, sound, centerH, centerV, bounds, scripts)
+        public TimedDialog(string message, bool sound, string soundEffect, int speakTime, bool centerH, bool centerV, Rect bounds, object[] scripts, int time, Action action)
+            : base(message, sound, soundEffect, speakTime, centerH, centerV, bounds, scripts)
         {
             this.time = time;
             this.action = action;

--- a/RogueEssence/Menu/MenuManager.cs
+++ b/RogueEssence/Menu/MenuManager.cs
@@ -149,9 +149,9 @@ namespace RogueEssence.Menu
             yield return CoroutineManager.Instance.StartCoroutine(ProcessMenuCoroutine(box));
         }
         
-        public IEnumerator<YieldInstruction> SetDialogue(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc, bool sound, Action finishAction, int waitTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, params string[] msgs)
+        public IEnumerator<YieldInstruction> SetDialogue(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc, bool sound, string soundEffect, int speakTime, Action finishAction, int waitTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, params string[] msgs)
         {
-            DialogueBox box = CreateDialogue(speaker, speakerName, emotion, speakerLoc, sound, finishAction, waitTime, autoFinish, centerH, centerV, bounds, scripts, msgs);
+            DialogueBox box = CreateDialogue(speaker, speakerName, emotion, speakerLoc, sound, soundEffect, speakTime, finishAction, waitTime, autoFinish, centerH, centerV, bounds, scripts, msgs);
             yield return CoroutineManager.Instance.StartCoroutine(ProcessMenuCoroutine(box));
         }
 
@@ -183,7 +183,7 @@ namespace RogueEssence.Menu
         {
             return CreateDialogue(speaker, speakerName, emotion, sound, () => { }, -1, false, false, false, msgs);
         }
-        public DialogueBox CreateDialogue(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc, bool sound, Action finishAction, int waitTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, params string[] msgs)
+        public DialogueBox CreateDialogue(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc, bool sound, string soundEffect, int speakTime, Action finishAction, int waitTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, params string[] msgs)
         {
             if (msgs.Length > 0)
             {
@@ -197,7 +197,7 @@ namespace RogueEssence.Menu
                 for (int ii = sep_msgs.Count - 1; ii >= 0; ii--)
                 {
                     DialogueBox prevBox = box;
-                    box = CreateBox(speaker, speakerName, emotion, speakerLoc, sound, (prevBox == null) ? finishAction : () => { AddMenu(prevBox, false); }, waitTime, autoFinish, centerH, centerV, bounds, scripts, sep_msgs[ii]);
+                    box = CreateBox(speaker, speakerName, emotion, speakerLoc, sound, soundEffect, speakTime, (prevBox == null) ? finishAction : () => { AddMenu(prevBox, false); }, waitTime, autoFinish, centerH, centerV, bounds, scripts, sep_msgs[ii]);
                 }
                 return box;
             }
@@ -206,18 +206,18 @@ namespace RogueEssence.Menu
         
         public DialogueBox CreateDialogue(MonsterID speaker, string speakerName, EmoteStyle emotion, bool sound, Action finishAction, int waitTime, bool autoFinish, bool centerH, bool centerV, params string[] msgs)
         {
-            return CreateDialogue(speaker, speakerName, emotion, SpeakerPortrait.DefaultLoc, sound, finishAction, waitTime, autoFinish, centerH,
+            return CreateDialogue(speaker, speakerName, emotion, SpeakerPortrait.DefaultLoc, sound, DialogueBox.SOUND_EFFECT, DialogueBox.SPEAK_FRAMES, finishAction, waitTime, autoFinish, centerH,
                 centerV, DialogueBox.DefaultBounds, new object[] {}, msgs);
         }
         
-        public DialogueBox CreateBox(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc, bool sound,
+        public DialogueBox CreateBox(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc, bool sound, string soundEffect, int speakTime,
              Action finishAction, int waitTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, string msg)
         {
             DialogueBox box = null;
             if (waitTime > -1)
-                box = new TimedDialog(msg, sound, centerH, centerV, bounds, scripts, waitTime, finishAction);
+                box = new TimedDialog(msg, sound, soundEffect, speakTime, centerH, centerV, bounds, scripts, waitTime, finishAction);
             else
-                box = new ClickedDialog(msg, sound, centerH, centerV, bounds, scripts, finishAction);
+                box = new ClickedDialog(msg, sound, soundEffect, speakTime, centerH, centerV, bounds, scripts, finishAction);
             box.SetSpeaker(speaker, speakerName, emotion, speakerLoc);
             if (autoFinish)
                 box.FinishText();
@@ -290,7 +290,7 @@ namespace RogueEssence.Menu
         }
         
         public DialogueBox CreateQuestion(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc,
-            string msg, bool sound, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, Loc menuLoc, Action yes, Action no, bool defaultNo)
+            string msg, bool sound, string soundEffect, int speakTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, Loc menuLoc, Action yes, Action no, bool defaultNo)
         {
             string[] break_str = Regex.Split(msg, "\\[br\\]", RegexOptions.IgnoreCase);
 
@@ -298,7 +298,7 @@ namespace RogueEssence.Menu
             choices[0] = new DialogueChoice(Text.FormatKey("DLG_CHOICE_YES"), yes);
             choices[1] = new DialogueChoice(Text.FormatKey("DLG_CHOICE_NO"), no);
 
-            DialogueBox box = new QuestionDialog(break_str[break_str.Length-1], sound, centerH, centerV, bounds, scripts, choices, defaultNo ? 1 : 0, 1, menuLoc);
+            DialogueBox box = new QuestionDialog(break_str[break_str.Length - 1], sound, soundEffect, speakTime, centerH, centerV, bounds, scripts, choices, defaultNo ? 1 : 0, 1, menuLoc);
             box.SetSpeaker(speaker, speakerName, emotion, speakerLoc);
             if (autoFinish)
                 box.FinishText();
@@ -316,7 +316,7 @@ namespace RogueEssence.Menu
         public DialogueBox CreateQuestion(MonsterID speaker, string speakerName, EmoteStyle emotion,
             string msg, bool sound, bool autoFinish, bool centerH, bool centerV, Action yes, Action no, bool defaultNo)
         {
-            return CreateQuestion(speaker, speakerName, emotion, SpeakerPortrait.DefaultLoc, msg, sound, autoFinish, centerH, centerV, DialogueBox.DefaultBounds, new object[] {}, DialogueChoiceMenu.DefaultLoc, yes, no, defaultNo);
+            return CreateQuestion(speaker, speakerName, emotion, SpeakerPortrait.DefaultLoc, msg, sound, DialogueBox.SOUND_EFFECT, DialogueBox.SPEAK_FRAMES, autoFinish, centerH, centerV, DialogueBox.DefaultBounds, new object[] {}, DialogueChoiceMenu.DefaultLoc, yes, no, defaultNo);
         }
 
         public DialogueBox CreateMultiQuestion(string message, bool sound, List<DialogueChoice> choices, int defaultChoice, int cancelChoice)
@@ -330,12 +330,12 @@ namespace RogueEssence.Menu
         }
 
         public DialogueBox CreateMultiQuestion(MonsterID speaker, string speakerName, EmoteStyle emotion, Loc speakerLoc,
-            string msg, bool sound, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, Loc menuLoc, DialogueChoice[] choices, int defaultChoice, int cancelChoice)
+            string msg, bool sound, string soundEffect, int speakTime, bool autoFinish, bool centerH, bool centerV, Rect bounds, object[] scripts, Loc menuLoc, DialogueChoice[] choices, int defaultChoice, int cancelChoice)
         {
             string[] break_str = Regex.Split(msg, "\\[br\\]", RegexOptions.IgnoreCase);
 
             // TODO fix MultiQuestion
-            DialogueBox box = new QuestionDialog(break_str[break_str.Length - 1], sound, false, false, bounds, scripts, choices, defaultChoice, cancelChoice, menuLoc);
+            DialogueBox box = new QuestionDialog(break_str[break_str.Length - 1], sound, soundEffect, speakTime, false, false, bounds, scripts, choices, defaultChoice, cancelChoice, menuLoc);
             box.SetSpeaker(speaker, speakerName, emotion, speakerLoc);
             if (autoFinish)
                 box.FinishText();
@@ -354,7 +354,7 @@ namespace RogueEssence.Menu
             string msg, bool sound, bool autoFinish, bool centerH, bool centerV, DialogueChoice[] choices,
             int defaultChoice, int cancelChoice)
         {
-            return CreateMultiQuestion(speaker, speakerName, emotion, SpeakerPortrait.DefaultLoc, msg, sound, autoFinish, centerH, centerV, DialogueBox.DefaultBounds, new object[] {}, DialogueChoiceMenu.DefaultLoc,  choices, defaultChoice, cancelChoice);
+            return CreateMultiQuestion(speaker, speakerName, emotion, SpeakerPortrait.DefaultLoc, msg, sound, DialogueBox.SOUND_EFFECT, DialogueBox.SPEAK_FRAMES, autoFinish, centerH, centerV, DialogueBox.DefaultBounds, new object[] {}, DialogueChoiceMenu.DefaultLoc,  choices, defaultChoice, cancelChoice);
             
         }
         

--- a/RogueEssence/Text.cs
+++ b/RogueEssence/Text.cs
@@ -33,6 +33,7 @@ namespace RogueEssence
         public static Dictionary<string, LanguageSetting> LangNames;
 
         public static Regex MsgTags = new Regex(@"(?<pause>\[pause=(?<pauseval>\d+)\])" +
+                                                @"|(?<sound>\[sound=(?<soundval>[A-Za-z\/0-9\-_]*),?(?<speaktime>\d*)?\])" +
                                                 @"|(?<colorstart>\[color=#(?<colorval>[0-9a-f]{6})\])|(?<colorend>\[color\])" +
                                                 @"|(?<boxbreak>\[br\])" +
                                                 @"|(?<scrollbreak>\[scroll\])" +


### PR DESCRIPTION
Adds the following commands for TextDiologue:

- `SetSe(string newSe, int speakTime)` - Sets the speaker sound effect and the amount of frames in between

- `ResetSe()` - Resets the default speaker sound effect and time

- `SetSpeakerTime(int speakerTime)` - Sets the amount of frames in between each sound effect

Additionally, the `[sound]` tag is added where the optional integer represents the speak frames

Example Usage:
- `[sound=Battle/_UNK_DUN_Water_Drop,7]`
- `[sound=Menu/Speak]`
