### PR TITLE
Retain speaker portrait settings when no speaker name is specified

### DIFF
--- a/RogueEssence/Lua/ScriptUI.cs
+++ b/RogueEssence/Lua/ScriptUI.cs
@@ -563,7 +563,7 @@ namespace RogueEssence.Script
 
                 m_curchoice = MenuManager.Instance.CreateQuestion(
                     m_curspeakerID,m_curspeakerName,m_curspeakerEmo,m_curspeakerLoc,message,
-                    m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc,
+                    m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc,
                     () => { m_choiceresult = true; DataManager.Instance.LogUIPlay(1); },
                     () => { m_choiceresult = false; DataManager.Instance.LogUIPlay(0); },
                     bdefaultstono);
@@ -1392,7 +1392,7 @@ namespace RogueEssence.Script
 
                 //Make a choice menu, and display a speaker despite not having a name
                 m_curchoice = MenuManager.Instance.CreateMultiQuestion(m_curspeakerID, m_curspeakerName, m_curspeakerEmo, m_curspeakerLoc, 
-                            message, m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
+                            message, m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, scripts, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
             }
             catch (Exception e)
             {

--- a/RogueEssence/Lua/ScriptUI.cs
+++ b/RogueEssence/Lua/ScriptUI.cs
@@ -521,25 +521,12 @@ namespace RogueEssence.Script
                 if (message == null)
                     message = "";
 
-                if (m_curspeakerName != null)
-                {
-                    m_curchoice = MenuManager.Instance.CreateQuestion(m_curspeakerID,
-                                                                      m_curspeakerName,
-                                                                      m_curspeakerEmo,
-                                                                      m_curspeakerLoc,
-                                                                      message,
-                                                                      m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc,
-                                                                      () => { m_choiceresult = true; DataManager.Instance.LogUIPlay(1); },
-                                                                      () => { m_choiceresult = false; DataManager.Instance.LogUIPlay(0); },
-                                                                      bdefaultstono);
-                }
-                else
-                {
-                    m_curchoice = MenuManager.Instance.CreateQuestion(MonsterID.Invalid, null, new EmoteStyle(0), m_curspeakerLoc, message,
-                        m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc,
-                        () => { m_choiceresult = true; DataManager.Instance.LogUIPlay(1); },
-                        () => { m_choiceresult = false; DataManager.Instance.LogUIPlay(0); }, bdefaultstono);
-                }
+                m_curchoice = MenuManager.Instance.CreateQuestion(
+                    m_curspeakerID,m_curspeakerName,m_curspeakerEmo,m_curspeakerLoc,message,
+                    m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc,
+                    () => { m_choiceresult = true; DataManager.Instance.LogUIPlay(1); },
+                    () => { m_choiceresult = false; DataManager.Instance.LogUIPlay(0); },
+                    bdefaultstono);
             }
             catch (Exception e)
             {
@@ -1361,17 +1348,9 @@ namespace RogueEssence.Script
                 if (mappedCancel == null)
                     mappedCancel = -1;
 
-                //Make a choice menu, and check if we display a speaker or not
-                if (m_curspeakerName != null)
-                {
-                    m_curchoice = MenuManager.Instance.CreateMultiQuestion(m_curspeakerID, m_curspeakerName, m_curspeakerEmo, m_curspeakerLoc, 
+                //Make a choice menu, and display a speaker despite not having a name
+                m_curchoice = MenuManager.Instance.CreateMultiQuestion(m_curspeakerID, m_curspeakerName, m_curspeakerEmo, m_curspeakerLoc, 
                             message, m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
-                }
-                else
-                {
-                    m_curchoice = MenuManager.Instance.CreateMultiQuestion(MonsterID.Invalid, null, new EmoteStyle(0), m_curspeakerLoc,
-                            message, m_curspeakerSnd, m_curautoFinish, m_curcenter_h, m_curcenter_v, m_curbounds, m_curchoiceLoc, choices.ToArray(), mappedDefault.Value, mappedCancel.Value);
-                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This PR addresses corrects the `ChoiceMenuYesNo` and `BeginChoiceMenu` functions to be consistent with `TextDialog` in that having no speaker name does not prohibit the speaker emotion and portrait from being displayed. This observation was brought up by [AntyMew](https://discord.com/channels/534207185333256223/818266922734190603/1135739412270034994).