### PR TITLE
Disabled and hidden option for ground item events

### DIFF
--- a/RogueEssence/Ground/GroundItemEvent.cs
+++ b/RogueEssence/Ground/GroundItemEvent.cs
@@ -13,20 +13,37 @@ namespace RogueEssence.Ground
     public enum SelectionType
     {
         /// <summary>
-        /// apply to user
+        /// Apply to user
         /// </summary>
         Self,
         /// <summary>
-        /// apply to other party members
+        /// Apply to other party members
         /// </summary>
         Others,
     }
     
     public abstract class GroundItemEvent : GameEvent
     {
+        /// <summary>
+        /// The ground item menu label
+        /// </summary>
         public ItemData.UseType GroundUsageType;
+        
+        /// <summary>
+        /// Determines who the item should target
+        /// </summary>
         public SelectionType Selection;
         public abstract IEnumerator<YieldInstruction> Apply(GroundContext context);
+        
+        /// <summary>
+        /// Whether the action is hidden in the item menu
+        /// </summary>
+        public bool Hidden;
+        
+        /// <summary>
+        /// Whether the action is disabled in the item menu
+        /// </summary>
+        public bool Disabled;
     }
     
     [Serializable]

--- a/RogueEssence/Menu/Items/ItemChosenMenu.cs
+++ b/RogueEssence/Menu/Items/ItemChosenMenu.cs
@@ -47,44 +47,47 @@ namespace RogueEssence.Menu
                     {
                         int idx = ii;
                         GroundItemEvent groundEvent = entry.GroundUseActions[idx];
-                        Action action = () => UseSelfAction(idx);
-                        
-                        
-                        switch (groundEvent.Selection)
+                        if (!groundEvent.Hidden)
                         {
-                            case SelectionType.Others:
-                                action = () => UseOtherAction(idx);
-                                break;
-                        }
+                            Action action = () => UseSelfAction(idx);
 
-                        // Note the hardcode for LearnItemAction
-                        if (groundEvent is LearnItemEvent)
-                        {
-                            action = () => TeachOtherAction(idx);
-                        }
 
-                        string actionName = "";
-                        switch (groundEvent.GroundUsageType)
-                        {
-                            case ItemData.UseType.Eat:
-                                actionName = Text.FormatKey("MENU_ITEM_EAT");
-                                break;
-                            case ItemData.UseType.Drink:
-                                actionName = Text.FormatKey("MENU_ITEM_DRINK");
-                                break;
-                            case ItemData.UseType.Use:
-                                actionName = Text.FormatKey("MENU_ITEM_USE");
-                                break;
-                            case ItemData.UseType.UseOther:
-                                actionName = Text.FormatKey("MENU_ITEM_USE");
-                                break;
-                            case ItemData.UseType.Learn:
-                                actionName = Text.FormatKey("MENU_ITEM_TEACH");
-                                break;
+                            switch (groundEvent.Selection)
+                            {
+                                case SelectionType.Others:
+                                    action = () => UseOtherAction(idx);
+                                    break;
+                            }
+
+                            // Note the hardcode for LearnItemAction
+                            if (groundEvent is LearnItemEvent)
+                            {
+                                action = () => TeachOtherAction(idx);
+                            }
+
+                            string actionName = "";
+                            switch (groundEvent.GroundUsageType)
+                            {
+                                case ItemData.UseType.Eat:
+                                    actionName = Text.FormatKey("MENU_ITEM_EAT");
+                                    break;
+                                case ItemData.UseType.Drink:
+                                    actionName = Text.FormatKey("MENU_ITEM_DRINK");
+                                    break;
+                                case ItemData.UseType.Use:
+                                    actionName = Text.FormatKey("MENU_ITEM_USE");
+                                    break;
+                                case ItemData.UseType.UseOther:
+                                    actionName = Text.FormatKey("MENU_ITEM_USE");
+                                    break;
+                                case ItemData.UseType.Learn:
+                                    actionName = Text.FormatKey("MENU_ITEM_TEACH");
+                                    break;
+                            }
+
+                            choices.Add(new MenuTextChoice(actionName, action, !invItem.Cursed && !groundEvent.Disabled,
+                                invItem.Cursed || groundEvent.Disabled ? Color.Red : Color.White));
                         }
-                        
-                        choices.Add(new MenuTextChoice(actionName, action, !invItem.Cursed,
-                            invItem.Cursed ? Color.Red : Color.White));
                     }
                 }
                 else if (GameManager.Instance.CurrentScene == DungeonScene.Instance)


### PR DESCRIPTION
Adds the two additional variables to GroundItemEvent, when then can be interfaced with Lua. There might be a better way of doing this.

- Disabled - Whether the item action is disabled
- Hidden - Whether the item action is hidden

Original:
<img width="200" alt="Screen Shot 2023-12-19 at 11 24 57 PM" src="https://github.com/RogueCollab/RogueEssence/assets/41309226/887c2e3a-bdf5-4674-a0c3-caee68a81d23">

Disabled:
<img width="200" alt="Screen Shot 2023-12-19 at 11 25 07 PM" src="https://github.com/RogueCollab/RogueEssence/assets/41309226/e056051d-62b7-469d-8d4d-3a4544a789d2">

Hidden:
<img width="200" alt="Screen Shot 2023-12-19 at 11 25 18 PM" src="https://github.com/RogueCollab/RogueEssence/assets/41309226/4f8d14ef-ab65-44a0-96ea-fbc6175e432c">


