### PR TITLE
Add mechanism that disallows players to take certain moves away from characters

### DIFF
--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -1246,20 +1246,6 @@ namespace RogueEssence.Dungeon
         public void SetSkillLocking(int slot, bool lck)
         {
             BaseSkills[slot].CanForget = !lck;
-
-            //update the backreferences 
-            int owningSlot = -1;
-            for (int ii = 0; ii < Skills.Count; ii++)
-            {
-                if (Skills[ii].BackRef > slot)
-                    Skills[ii].BackRef--;
-                else if (Skills[ii].BackRef == slot)
-                    owningSlot = ii;
-            }
-            if (owningSlot > -1)
-            {
-                Skills[owningSlot].Element.CanForget = !lck;
-            }
         }
 
         public void DeleteSkill(int slot, bool refresh=true)

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -1243,6 +1243,24 @@ namespace RogueEssence.Dungeon
             RefreshTraits();
         }
 
+        public void SetSkillLocking(int slot, bool lck)
+        {
+            BaseSkills[slot].CanForget = !lck;
+
+            //update the backreferences 
+            int owningSlot = -1;
+            for (int ii = 0; ii < Skills.Count; ii++)
+            {
+                if (Skills[ii].BackRef > slot)
+                    Skills[ii].BackRef--;
+                else if (Skills[ii].BackRef == slot)
+                    owningSlot = ii;
+            }
+            if (owningSlot > -1)
+            {
+                Skills[owningSlot].Element.CanForget = !lck;
+            }
+        }
 
         public void DeleteSkill(int slot, bool refresh=true)
         {

--- a/RogueEssence/Dungeon/Characters/Skill.cs
+++ b/RogueEssence/Dungeon/Characters/Skill.cs
@@ -12,7 +12,6 @@ namespace RogueEssence.Dungeon
         [JsonConverter(typeof(SkillConverter))]
         public string SkillNum;
         public int Charges;
-        public bool CanForget;
         public bool Enabled;
 
         public bool Sealed;
@@ -29,7 +28,6 @@ namespace RogueEssence.Dungeon
             SkillNum = skillNum;
             Charges = charges;
             Enabled = enabled;
-            CanForget = true;
         }
     }
 }

--- a/RogueEssence/Dungeon/Characters/Skill.cs
+++ b/RogueEssence/Dungeon/Characters/Skill.cs
@@ -12,6 +12,7 @@ namespace RogueEssence.Dungeon
         [JsonConverter(typeof(SkillConverter))]
         public string SkillNum;
         public int Charges;
+        public bool CanForget;
         public bool Enabled;
 
         public bool Sealed;
@@ -28,6 +29,7 @@ namespace RogueEssence.Dungeon
             SkillNum = skillNum;
             Charges = charges;
             Enabled = enabled;
+            CanForget = true;
         }
     }
 }

--- a/RogueEssence/Dungeon/Characters/SlotSkill.cs
+++ b/RogueEssence/Dungeon/Characters/SlotSkill.cs
@@ -11,16 +11,19 @@ namespace RogueEssence.Dungeon
         [JsonConverter(typeof(SkillConverter))]
         public string SkillNum;
         public int Charges;
+        public bool CanForget;
 
         public SlotSkill() : this("") { }
 
         public SlotSkill(string skillNum)
         {
             SkillNum = skillNum;
+            CanForget = true;
         }
         public SlotSkill(SlotSkill other)
         {
             SkillNum = other.SkillNum;
+            CanForget = other.CanForget;
         }
     }
 }

--- a/RogueEssence/Lua/ScriptGame.cs
+++ b/RogueEssence/Lua/ScriptGame.cs
@@ -787,6 +787,27 @@ namespace RogueEssence.Script
         }
 
         /// <summary>
+        /// Makes a skill impossible to forget or replace for the specified character.
+        /// Note that this only affects normal gameplay. Scripts can still freely get rid of the skill.
+        /// </summary>
+        /// <param name="chara">The character to lock the skill</param>
+        /// <param name="slot">The slot of the skill to lock</param>
+        public void LockSkill(Character chara, int slot)
+        {
+            chara.SetSkillLocking(slot, true);
+        }
+
+        /// <summary>
+        /// Unlocks a previously locked skill for the specified character, making it possible to be forgotten or replaced during normal gameplay.
+        /// </summary>
+        /// <param name="chara">The character to unlock the skill</param>
+        /// <param name="slot">The slot of the skill to unlock</param>
+        public void UnlockSkill(Character chara, int slot)
+        {
+            chara.SetSkillLocking(slot, false);
+        }
+
+        /// <summary>
         /// Gives a new skill to a specified character, replacing a specifically chosen slot.
         /// </summary>
         /// <param name="character">The character to learn the skill</param>

--- a/RogueEssence/Menu/Skills/SkillForgetMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillForgetMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
 using RogueElements;
@@ -32,13 +33,14 @@ namespace RogueEssence.Menu
                 {
                     bool enabled = skill.CanForget;
                     SkillData data = DataManager.Instance.GetSkill(skill.SkillNum);
-                    string skillString = enabled ? data.GetColoredName() : String.Format("[color=#FF0000]{0}[color]", data.Name.ToLocal());
+                    string skillString = data.GetColoredName();
                     string skillCharges = skill.Charges + "/" + (data.BaseCharges + player.ChargeBoost);
+                    Color color = Color.White;
                     if (!enabled)
-                        skillCharges = String.Format("[color=#FF0000]{0}[color]", skillCharges);
+                        color = Color.Red;
                     int index = ii;
-                    MenuText menuText = new MenuText(skillString, new Loc(2, 1));
-                    MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirH.Right);
+                    MenuText menuText = new MenuText(skillString, new Loc(2, 1), color);
+                    MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirV.Up, DirH.Right, color);
                     if (ii < Character.MAX_SKILL_SLOTS - 1)
                     {
                         MenuDivider div = new MenuDivider(new Loc(0, LINE_HEIGHT), menuWidth - 8 * 4);

--- a/RogueEssence/Menu/Skills/SkillForgetMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillForgetMenu.cs
@@ -30,19 +30,22 @@ namespace RogueEssence.Menu
                 SlotSkill skill = player.BaseSkills[ii];
                 if (!String.IsNullOrEmpty(skill.SkillNum))
                 {
+                    bool enabled = skill.CanForget;
                     SkillData data = DataManager.Instance.GetSkill(skill.SkillNum);
-                    string skillString = data.GetColoredName();
+                    string skillString = enabled ? data.GetColoredName() : String.Format("[color=#FF0000]{0}[color]", data.Name.ToLocal());
                     string skillCharges = skill.Charges + "/" + (data.BaseCharges + player.ChargeBoost);
+                    if (!enabled)
+                        skillCharges = String.Format("[color=#FF0000]{0}[color]", skillCharges);
                     int index = ii;
                     MenuText menuText = new MenuText(skillString, new Loc(2, 1));
                     MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirH.Right);
                     if (ii < Character.MAX_SKILL_SLOTS - 1)
                     {
                         MenuDivider div = new MenuDivider(new Loc(0, LINE_HEIGHT), menuWidth - 8 * 4);
-                        char_skills.Add(new MenuElementChoice(() => { choose(index); }, true, menuText, menuCharges, div));
+                        char_skills.Add(new MenuElementChoice(() => { choose(index); }, enabled, menuText, menuCharges, div));
                     }
                     else
-                        char_skills.Add(new MenuElementChoice(() => { choose(index); }, true, menuText, menuCharges));
+                        char_skills.Add(new MenuElementChoice(() => { choose(index); }, enabled, menuText, menuCharges));
                 }
             }
 

--- a/RogueEssence/Menu/Skills/SkillReplaceMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillReplaceMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
 using RogueElements;
@@ -33,13 +34,14 @@ namespace RogueEssence.Menu
                 {
                     bool enabled = skill.CanForget;
                     SkillData data = DataManager.Instance.GetSkill(skill.SkillNum);
-                    string skillString = enabled ? data.GetColoredName() : String.Format("[color=#FF0000]{0}[color]", data.Name.ToLocal());
+                    string skillString = data.GetColoredName();
                     string skillCharges = skill.Charges + "/" + (data.BaseCharges + player.ChargeBoost);
+                    Color color = Color.White;
                     if (!enabled)
-                        skillCharges = String.Format("[color=#FF0000]{0}[color]", skillCharges);
+                        color = Color.Red;
                     int index = ii;
-                    MenuText menuText = new MenuText(skillString, new Loc(2, 1));
-                    MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirH.Right);
+                    MenuText menuText = new MenuText(skillString, new Loc(2, 1), color);
+                    MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirV.Up, DirH.Right, color);
                     MenuDivider div = new MenuDivider(new Loc(0, LINE_HEIGHT), menuWidth - 8 * 4);
                     char_skills.Add(new MenuElementChoice(() => { choose(index); }, enabled, menuText, menuCharges, div));
                 }

--- a/RogueEssence/Menu/Skills/SkillReplaceMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillReplaceMenu.cs
@@ -31,14 +31,17 @@ namespace RogueEssence.Menu
                 SlotSkill skill = player.BaseSkills[ii];
                 if (!String.IsNullOrEmpty(skill.SkillNum))
                 {
+                    bool enabled = skill.CanForget;
                     SkillData data = DataManager.Instance.GetSkill(skill.SkillNum);
-                    string skillString = data.GetColoredName();
+                    string skillString = enabled ? data.GetColoredName() : String.Format("[color=#FF0000]{0}[color]", data.Name.ToLocal());
                     string skillCharges = skill.Charges + "/" + (data.BaseCharges + player.ChargeBoost);
+                    if (!enabled)
+                        skillCharges = String.Format("[color=#FF0000]{0}[color]", skillCharges);
                     int index = ii;
                     MenuText menuText = new MenuText(skillString, new Loc(2, 1));
                     MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirH.Right);
                     MenuDivider div = new MenuDivider(new Loc(0, LINE_HEIGHT), menuWidth - 8 * 4);
-                    char_skills.Add(new MenuElementChoice(() => { choose(index); }, true, menuText, menuCharges, div));
+                    char_skills.Add(new MenuElementChoice(() => { choose(index); }, enabled, menuText, menuCharges, div));
                 }
             }
             string newSkillString = DataManager.Instance.GetSkill(skillNum).GetColoredName();


### PR DESCRIPTION
- This PR adds a ``CanForget`` property to SkillSlots. It is always true upon initialization.
- Characters have a new ``SetSkillLocking`` method, also accessible through ``GAME:LockSkill`` and ``GAME:UnlockSkill``, that changes the ``CanForget`` state of a chosen skill slot.
- ``SkillForgetMenu`` and ``SkillReplaceMenu`` will then disallow selecting any locked skill, effectively making it impossible for a player to remove locked skills during normal gameplay.

Level-up example after locking slot id 1 of the player character:
![immagine](https://github.com/RogueCollab/RogueEssence/assets/48797892/130da8a2-cfaa-4802-a638-e6ca393a652f)
