### PR TITLE
Item-related menus reselect items upon sorting

### DIFF
--- a/RogueEssence/Dungeon/Team.cs
+++ b/RogueEssence/Dungeon/Team.cs
@@ -261,6 +261,42 @@ namespace RogueEssence.Dungeon
             inventory = newInv;
         }
 
+        /// <summary>
+        /// Checks the current order of items and returns a dictionary that maps their current positions with the sorted ones.<br/>
+        /// It is important to note that this function does NOT actually sort the inventory. It only calculates a preview.<br/>
+        /// Keys: sorted order; Values: current order.
+        /// If swap is true, keys and values will be swapped with each other before returning.
+        /// </summary>
+        public Dictionary<int, int> GetSortMapping(bool swap)
+        {
+            List<int> newToOld = new List<int>();
+            //for each inv item
+            for (int kk = 0; kk < inventory.Count; kk++)
+            {
+                //find its new place
+                for (int ii = newToOld.Count; ii >= 0; ii--)
+                {
+                    if (ii == 0 || succeedsInvItem(inventory[kk], inventory[newToOld[ii - 1]]))
+                    {
+                        newToOld.Insert(ii, kk);
+                        break;
+                    }
+                }
+            }
+            Dictionary<int, int> ret = new Dictionary<int, int>();
+            if (swap)
+            {
+                for (int ii = 0; ii < newToOld.Count; ii++)
+                    ret[newToOld[ii]] = ii;
+            }
+            else
+            {
+                for (int ii = 0; ii < newToOld.Count; ii++)
+                    ret[ii] = newToOld[ii];
+            }
+            return ret;
+        }
+
         private bool succeedsInvItem(InvItem inv1, InvItem inv2)
         {
             return DataManager.Instance.DataIndices[DataManager.DataType.Item].CompareWithSort(inv1.ID, inv2.ID) > 0;

--- a/RogueEssence/Dungeon/Team.cs
+++ b/RogueEssence/Dungeon/Team.cs
@@ -299,7 +299,7 @@ namespace RogueEssence.Dungeon
 
         private bool succeedsInvItem(InvItem inv1, InvItem inv2)
         {
-            return DataManager.Instance.DataIndices[DataManager.DataType.Item].CompareWithSort(inv1.ID, inv2.ID) > 0;
+            return DataManager.Instance.DataIndices[DataManager.DataType.Item].CompareWithSort(inv1.ID, inv2.ID) >= 0;
         }
 
         public int GetInvValue()

--- a/RogueEssence/Menu/Items/AppraiseMenu.cs
+++ b/RogueEssence/Menu/Items/AppraiseMenu.cs
@@ -165,12 +165,10 @@ namespace RogueEssence.Menu
                     eqIndex++;
                 }
             }
-            int pos = eqIndex;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
-                if (GetTotalChoiceAtIndex(pos).Selected)
+                if (GetTotalChoiceAtIndex(eqIndex + ii).Selected)
                     selected.Add(ii);
-                pos++;
             }
 
             // get mapping

--- a/RogueEssence/Menu/Items/AppraiseMenu.cs
+++ b/RogueEssence/Menu/Items/AppraiseMenu.cs
@@ -155,25 +155,26 @@ namespace RogueEssence.Menu
             //generate list of selected items
             List<int> equip_selected = new List<int>();
             List<InvItem> selected = new List<InvItem>();
-            int pos = 0;
+            int eqs = 0;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
             {
                 Character activeChar = DataManager.Instance.Save.ActiveTeam.Players[ii];
                 if (!String.IsNullOrEmpty(activeChar.EquippedItem.ID))
                 {
-                    int page = pos / SLOTS_PER_PAGE;
-                    int elem = pos % SLOTS_PER_PAGE;
+                    int page = eqs / SLOTS_PER_PAGE;
+                    int elem = eqs % SLOTS_PER_PAGE;
                     if (TotalChoices[page][elem].Selected)
-                        equip_selected.Add(ii);
-                    pos++;
+                        equip_selected.Add(eqs);
+                    eqs++;
                 }
             }
+            int pos = eqs;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
                 int page = pos / SLOTS_PER_PAGE;
                 int elem = pos % SLOTS_PER_PAGE;
                 if (TotalChoices[page][elem].Selected)
-                    selected.Add(new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii)));
+                    selected.Add(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
                 pos++;
             }
 
@@ -191,8 +192,7 @@ namespace RogueEssence.Menu
                 ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
             }
             // reselect the rest of the inventory
-            pos = equip_selected.Count;
-            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
+            for (int ii = DataManager.Instance.Save.ActiveTeam.GetInvCount() - 1; ii >= 0; ii--)
             {
                 InvItem item = new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
                 // look for equivalent item
@@ -211,12 +211,12 @@ namespace RogueEssence.Menu
                 // reselect the item
                 if (loc >= 0)
                 {
-                    int page = pos / SLOTS_PER_PAGE;
-                    int elem = pos % SLOTS_PER_PAGE;
+                    int index = ii + eqs;
+                    int page = index / SLOTS_PER_PAGE;
+                    int elem = index % SLOTS_PER_PAGE;
                     ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
                     selected.RemoveAt(loc);
                 }
-                pos++;
             }
 
             //replace the menu

--- a/RogueEssence/Menu/Items/AppraiseMenu.cs
+++ b/RogueEssence/Menu/Items/AppraiseMenu.cs
@@ -153,6 +153,7 @@ namespace RogueEssence.Menu
         public IEnumerator<YieldInstruction> SortCommand()
         {
             //generate list of selected items
+            List<int> equip_selected = new List<int>();
             List<InvItem> selected = new List<InvItem>();
             int pos = 0;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
@@ -163,7 +164,7 @@ namespace RogueEssence.Menu
                     int page = pos / SLOTS_PER_PAGE;
                     int elem = pos % SLOTS_PER_PAGE;
                     if (TotalChoices[page][elem].Selected)
-                        selected.Add(new InvItem(activeChar.EquippedItem));
+                        equip_selected.Add(ii);
                     pos++;
                 }
             }
@@ -181,37 +182,16 @@ namespace RogueEssence.Menu
             // create the new menu
             AppraiseMenu menu = new AppraiseMenu(CurrentChoiceTotal, action);
 
-            // reselect the items
-            pos = 0;
-            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
+            // reselet equip slots
+            for (int ii = 0; ii < equip_selected.Count; ii++)
             {
-                InvItem item = DataManager.Instance.Save.ActiveTeam.Players[ii].EquippedItem;
-                if (!String.IsNullOrEmpty(item.ID))
-                {
-                    // look for equivalent item
-                    int loc = -1;
-                    for (int j = 0; j < selected.Count; j++)
-                    {
-                        InvItem slot = selected[j];
-                        if (slot.ID == item.ID && slot.Amount == item.Amount &&
-                            slot.Price == item.Price && slot.Cursed == item.Cursed &&
-                            slot.HiddenValue == item.HiddenValue)
-                        {
-                            loc = j;
-                            break;
-                        }
-                    }
-                    // reselect the item
-                    if (loc >= 0)
-                    {
-                        int page = pos / SLOTS_PER_PAGE;
-                        int elem = pos % SLOTS_PER_PAGE;
-                        ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
-                        selected.RemoveAt(loc);
-                    }
-                    pos++;
-                }
+                int slot = equip_selected[ii];
+                int page = slot / SLOTS_PER_PAGE;
+                int elem = slot % SLOTS_PER_PAGE;
+                ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
             }
+            // reselect the rest of the inventory
+            pos = equip_selected.Count;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
                 InvItem item = new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii));

--- a/RogueEssence/Menu/Items/AppraiseMenu.cs
+++ b/RogueEssence/Menu/Items/AppraiseMenu.cs
@@ -149,7 +149,6 @@ namespace RogueEssence.Menu
             moneySummary.Draw(spriteBatch);
         }
 
-        //TODO deal with this
         public IEnumerator<YieldInstruction> SortCommand()
         {
             //generate list of selected items

--- a/RogueEssence/Menu/Items/AppraiseMenu.cs
+++ b/RogueEssence/Menu/Items/AppraiseMenu.cs
@@ -148,11 +148,99 @@ namespace RogueEssence.Menu
             summaryMenu.Draw(spriteBatch);
             moneySummary.Draw(spriteBatch);
         }
-        
+
+
         public IEnumerator<YieldInstruction> SortCommand()
         {
+            //generate list of selected items
+            List<InvItem> selected = new List<InvItem>();
+            int pos = 0;
+            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
+            {
+                Character activeChar = DataManager.Instance.Save.ActiveTeam.Players[ii];
+                if (!String.IsNullOrEmpty(activeChar.EquippedItem.ID))
+                {
+                    int page = pos / SLOTS_PER_PAGE;
+                    int elem = pos % SLOTS_PER_PAGE;
+                    if (TotalChoices[page][elem].Selected)
+                        selected.Add(new InvItem(activeChar.EquippedItem));
+                    pos++;
+                }
+            }
+            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
+            {
+                int page = pos / SLOTS_PER_PAGE;
+                int elem = pos % SLOTS_PER_PAGE;
+                if (TotalChoices[page][elem].Selected)
+                    selected.Add(new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii)));
+                pos++;
+            }
+
+            // reorder the inventory
             yield return CoroutineManager.Instance.StartCoroutine(GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.SortItems, Dir8.None)));
-            MenuManager.Instance.ReplaceMenu(new AppraiseMenu(CurrentChoiceTotal, action));
+            // create the new menu
+            AppraiseMenu menu = new AppraiseMenu(CurrentChoiceTotal, action);
+
+            // reselect the items
+            pos = 0;
+            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
+            {
+                InvItem item = DataManager.Instance.Save.ActiveTeam.Players[ii].EquippedItem;
+                if (!String.IsNullOrEmpty(item.ID))
+                {
+                    // look for equivalent item
+                    int loc = -1;
+                    for (int j = 0; j < selected.Count; j++)
+                    {
+                        InvItem slot = selected[j];
+                        if (slot.ID == item.ID && slot.Amount == item.Amount &&
+                            slot.Price == item.Price && slot.Cursed == item.Cursed &&
+                            slot.HiddenValue == item.HiddenValue)
+                        {
+                            loc = j;
+                            break;
+                        }
+                    }
+                    // reselect the item
+                    if (loc >= 0)
+                    {
+                        int page = pos / SLOTS_PER_PAGE;
+                        int elem = pos % SLOTS_PER_PAGE;
+                        ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
+                        selected.RemoveAt(loc);
+                    }
+                    pos++;
+                }
+            }
+            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
+            {
+                InvItem item = new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
+                // look for equivalent item
+                int loc = -1;
+                for (int j = 0; j < selected.Count; j++)
+                {
+                    InvItem slot = selected[j];
+                    if (slot.ID == item.ID && slot.Amount == item.Amount &&
+                        slot.Price == item.Price && slot.Cursed == item.Cursed &&
+                        slot.HiddenValue == item.HiddenValue)
+                    {
+                        loc = j;
+                        break;
+                    }
+                }
+                // reselect the item
+                if (loc >= 0)
+                {
+                    int page = pos / SLOTS_PER_PAGE;
+                    int elem = pos % SLOTS_PER_PAGE;
+                    ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
+                    selected.RemoveAt(loc);
+                }
+                pos++;
+            }
+
+            //replace the menu
+            MenuManager.Instance.ReplaceMenu(menu);
         }
     }
 }

--- a/RogueEssence/Menu/Items/DepositMenu.cs
+++ b/RogueEssence/Menu/Items/DepositMenu.cs
@@ -132,7 +132,8 @@ namespace RogueEssence.Menu
         public IEnumerator<YieldInstruction> SortCommand()
         {
             //generate list of selected items
-            List<InvItem> selected = new List<InvItem>();
+            List<int> equip_selected = new List<int>();
+            List<InvItem> selected   = new List<InvItem>();
             int pos = 0;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
             {
@@ -142,7 +143,7 @@ namespace RogueEssence.Menu
                     int page = pos / SLOTS_PER_PAGE;
                     int elem = pos % SLOTS_PER_PAGE;
                     if (TotalChoices[page][elem].Selected)
-                        selected.Add(new InvItem(activeChar.EquippedItem));
+                        equip_selected.Add(ii);
                     pos++;
                 }
             }
@@ -160,37 +161,16 @@ namespace RogueEssence.Menu
             // create the new menu
             DepositMenu menu = new DepositMenu(CurrentChoiceTotal);
 
-            // reselect the items
-            pos = 0;
-            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
+            // reselet equip slots
+            for (int ii = 0; ii < equip_selected.Count; ii++)
             {
-                InvItem item = DataManager.Instance.Save.ActiveTeam.Players[ii].EquippedItem;
-                if (!String.IsNullOrEmpty(item.ID))
-                {
-                    // look for equivalent item
-                    int loc = -1;
-                    for (int j = 0; j < selected.Count; j++)
-                    {
-                        InvItem slot = selected[j];
-                        if (slot.ID    == item.ID    && slot.Amount == item.Amount &&
-                            slot.Price == item.Price && slot.Cursed == item.Cursed &&
-                            slot.HiddenValue == item.HiddenValue)
-                        {
-                            loc = j;
-                            break;
-                        }
-                    }
-                    // reselect the item
-                    if (loc >= 0)
-                    {
-                        int page = pos / SLOTS_PER_PAGE;
-                        int elem = pos % SLOTS_PER_PAGE;
-                        ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
-                        selected.RemoveAt(loc);
-                    }
-                    pos++;
-                }
+                int slot = equip_selected[ii];
+                int page = slot / SLOTS_PER_PAGE;
+                int elem = slot % SLOTS_PER_PAGE;
+                ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
             }
+            // reselect the rest of the inventory
+            pos = equip_selected.Count;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
                 InvItem item = new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii));

--- a/RogueEssence/Menu/Items/DepositMenu.cs
+++ b/RogueEssence/Menu/Items/DepositMenu.cs
@@ -134,25 +134,26 @@ namespace RogueEssence.Menu
             //generate list of selected items
             List<int> equip_selected = new List<int>();
             List<InvItem> selected   = new List<InvItem>();
-            int pos = 0;
+            int eqs = 0;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
             {
                 Character activeChar = DataManager.Instance.Save.ActiveTeam.Players[ii];
                 if (!String.IsNullOrEmpty(activeChar.EquippedItem.ID))
                 {
-                    int page = pos / SLOTS_PER_PAGE;
-                    int elem = pos % SLOTS_PER_PAGE;
+                    int page = eqs / SLOTS_PER_PAGE;
+                    int elem = eqs % SLOTS_PER_PAGE;
                     if (TotalChoices[page][elem].Selected)
-                        equip_selected.Add(ii);
-                    pos++;
+                        equip_selected.Add(eqs);
+                    eqs++;
                 }
             }
+            int pos = eqs;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
                 int page = pos / SLOTS_PER_PAGE;
                 int elem = pos % SLOTS_PER_PAGE;
                 if (TotalChoices[page][elem].Selected)
-                    selected.Add(new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii)));
+                    selected.Add(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
                 pos++;
             }
 
@@ -170,8 +171,7 @@ namespace RogueEssence.Menu
                 ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
             }
             // reselect the rest of the inventory
-            pos = equip_selected.Count;
-            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
+            for (int ii = DataManager.Instance.Save.ActiveTeam.GetInvCount() - 1; ii >= 0; ii--)
             {
                 InvItem item = new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
                 // look for equivalent item
@@ -190,12 +190,12 @@ namespace RogueEssence.Menu
                 // reselect the item
                 if (loc >= 0)
                 {
-                    int page = pos / SLOTS_PER_PAGE;
-                    int elem = pos % SLOTS_PER_PAGE;
+                    int index = ii + eqs;
+                    int page = index / SLOTS_PER_PAGE;
+                    int elem = index % SLOTS_PER_PAGE;
                     ((MenuChoice) menu.TotalChoices[page][elem]).SilentSelect(true);
                     selected.RemoveAt(loc);
                 }
-                pos++;
             }
 
             //replace the menu

--- a/RogueEssence/Menu/Items/DepositMenu.cs
+++ b/RogueEssence/Menu/Items/DepositMenu.cs
@@ -145,12 +145,10 @@ namespace RogueEssence.Menu
                     eqIndex++;
                 }
             }
-            int pos = eqIndex;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
-                if (GetTotalChoiceAtIndex(pos).Selected)
+                if (GetTotalChoiceAtIndex(eqIndex + ii).Selected)
                     selected.Add(ii);
-                pos++;
             }
 
             // get mapping

--- a/RogueEssence/Menu/Items/DepositMenu.cs
+++ b/RogueEssence/Menu/Items/DepositMenu.cs
@@ -133,69 +133,47 @@ namespace RogueEssence.Menu
         {
             //generate list of selected items
             List<int> equip_selected = new List<int>();
-            List<InvItem> selected   = new List<InvItem>();
-            int eqs = 0;
+            List<int> selected = new List<int>();
+            int eqIndex = 0;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
             {
                 Character activeChar = DataManager.Instance.Save.ActiveTeam.Players[ii];
                 if (!String.IsNullOrEmpty(activeChar.EquippedItem.ID))
                 {
-                    int page = eqs / SLOTS_PER_PAGE;
-                    int elem = eqs % SLOTS_PER_PAGE;
-                    if (TotalChoices[page][elem].Selected)
-                        equip_selected.Add(eqs);
-                    eqs++;
+                    if (GetTotalChoiceAtIndex(eqIndex).Selected)
+                        equip_selected.Add(eqIndex);
+                    eqIndex++;
                 }
             }
-            int pos = eqs;
+            int pos = eqIndex;
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
-                int page = pos / SLOTS_PER_PAGE;
-                int elem = pos % SLOTS_PER_PAGE;
-                if (TotalChoices[page][elem].Selected)
-                    selected.Add(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
+                if (GetTotalChoiceAtIndex(pos).Selected)
+                    selected.Add(ii);
                 pos++;
             }
+
+            // get mapping
+            Dictionary<int, int> mapping = DataManager.Instance.Save.ActiveTeam.GetSortMapping(true);
 
             // reorder the inventory
             yield return CoroutineManager.Instance.StartCoroutine(GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.SortItems, Dir8.None)));
             // create the new menu
             DepositMenu menu = new DepositMenu(CurrentChoiceTotal);
 
-            // reselet equip slots
+            // reselect equip slots
             for (int ii = 0; ii < equip_selected.Count; ii++)
             {
                 int slot = equip_selected[ii];
-                int page = slot / SLOTS_PER_PAGE;
-                int elem = slot % SLOTS_PER_PAGE;
-                ((MenuChoice)menu.TotalChoices[page][elem]).SilentSelect(true);
+                ((MenuChoice)menu.GetTotalChoiceAtIndex(slot)).SilentSelect(true);
             }
             // reselect the rest of the inventory
-            for (int ii = DataManager.Instance.Save.ActiveTeam.GetInvCount() - 1; ii >= 0; ii--)
+            for (int ii = selected.Count - 1; ii >= 0; ii--)
             {
-                InvItem item = new InvItem(DataManager.Instance.Save.ActiveTeam.GetInv(ii));
-                // look for equivalent item
-                int loc = -1;
-                for (int j = 0; j < selected.Count; j++)
-                {
-                    InvItem slot = selected[j];
-                    if (slot.ID == item.ID && slot.Amount == item.Amount &&
-                        slot.Price == item.Price && slot.Cursed == item.Cursed &&
-                        slot.HiddenValue == item.HiddenValue)
-                    {
-                        loc = j;
-                        break;
-                    }
-                }
-                // reselect the item
-                if (loc >= 0)
-                {
-                    int index = ii + eqs;
-                    int page = index / SLOTS_PER_PAGE;
-                    int elem = index % SLOTS_PER_PAGE;
-                    ((MenuChoice) menu.TotalChoices[page][elem]).SilentSelect(true);
-                    selected.RemoveAt(loc);
-                }
+                int oldPos = selected[ii];
+                int newPos = mapping[oldPos];
+                int index = newPos + eqIndex;
+                ((MenuChoice)menu.GetTotalChoiceAtIndex(index)).SilentSelect(true);
             }
 
             //replace the menu

--- a/RogueEssence/Menu/Items/SellMenu.cs
+++ b/RogueEssence/Menu/Items/SellMenu.cs
@@ -183,12 +183,11 @@ namespace RogueEssence.Menu
                     eqIndex++;
                 }
             }
-            int pos = eqIndex;
+            
             for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
             {
-                if (GetTotalChoiceAtIndex(pos).Selected)
+                if (GetTotalChoiceAtIndex(eqIndex + ii).Selected)
                     selected.Add(ii);
-                pos++;
             }
 
             // get mapping

--- a/RogueEssence/Menu/Items/SellMenu.cs
+++ b/RogueEssence/Menu/Items/SellMenu.cs
@@ -169,8 +169,53 @@ namespace RogueEssence.Menu
         
         public IEnumerator<YieldInstruction> SortCommand()
         {
+            //generate list of selected items
+            List<int> equip_selected = new List<int>();
+            List<int> selected = new List<int>();
+            int eqIndex = 0;
+            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.Players.Count; ii++)
+            {
+                Character activeChar = DataManager.Instance.Save.ActiveTeam.Players[ii];
+                if (!String.IsNullOrEmpty(activeChar.EquippedItem.ID))
+                {
+                    if (GetTotalChoiceAtIndex(eqIndex).Selected)
+                        equip_selected.Add(eqIndex);
+                    eqIndex++;
+                }
+            }
+            int pos = eqIndex;
+            for (int ii = 0; ii < DataManager.Instance.Save.ActiveTeam.GetInvCount(); ii++)
+            {
+                if (GetTotalChoiceAtIndex(pos).Selected)
+                    selected.Add(ii);
+                pos++;
+            }
+
+            // get mapping
+            Dictionary<int, int> mapping = DataManager.Instance.Save.ActiveTeam.GetSortMapping(true);
+
+            // reorder the inventory
             yield return CoroutineManager.Instance.StartCoroutine(GroundScene.Instance.ProcessInput(new GameAction(GameAction.ActionType.SortItems, Dir8.None)));
-            MenuManager.Instance.ReplaceMenu(new SellMenu(CurrentChoiceTotal, action));
+            // create the new menu
+            SellMenu menu = new SellMenu(CurrentChoiceTotal, action);
+
+            // reselect equip slots
+            for (int ii = 0; ii < equip_selected.Count; ii++)
+            {
+                int slot = equip_selected[ii];
+                ((MenuChoice)menu.GetTotalChoiceAtIndex(slot)).SilentSelect(true);
+            }
+            // reselect the rest of the inventory
+            for (int ii = selected.Count - 1; ii >= 0; ii--)
+            {
+                int oldPos = selected[ii];
+                int newPos = mapping[oldPos];
+                int index = newPos + eqIndex;
+                ((MenuChoice)menu.GetTotalChoiceAtIndex(index)).SilentSelect(true);
+            }
+
+            //replace the menu
+            MenuManager.Instance.ReplaceMenu(menu);
         }
     }
 }

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -48,6 +48,14 @@ namespace RogueEssence.Menu
             this.click = clicked && hover;
         }
 
+        public void SilentSelect(bool select)
+        {
+            if (Enabled)
+            {
+                Selected = select;
+            }
+        }
+
         public void OnSelect(bool select)
         {
             if (Enabled)

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -129,7 +129,7 @@ namespace RogueEssence.Menu
                 base.UpdateKeys(input);
         }
 
-        protected IChoosable GetTotalChoiceAtIndex(int totalIndex)
+        public IChoosable GetTotalChoiceAtIndex(int totalIndex)
         {
             int page = totalIndex / SpacesPerPage;
             int index = totalIndex % SpacesPerPage;

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -128,5 +128,12 @@ namespace RogueEssence.Menu
             else
                 base.UpdateKeys(input);
         }
+
+        protected IChoosable GetTotalChoiceAtIndex(int totalIndex)
+        {
+            int page = totalIndex / SpacesPerPage;
+            int index = totalIndex % SpacesPerPage;
+            return TotalChoices[page][index];
+        }
     }
 }


### PR DESCRIPTION
- Items in the inventory get reselected from bottom to top
- If you select an equipped item, it will be reselected after sorting, no matter what
- Added a SilentSelect methodto MenuChoice to avoid calling the selection sound effect n times