### PR TITLE
TeachInfoMenu upgrade

### DIFF
--- a/RogueEssence/Menu/Items/TeachInfoMenu.cs
+++ b/RogueEssence/Menu/Items/TeachInfoMenu.cs
@@ -7,8 +7,10 @@ using RogueEssence.Dungeon;
 
 namespace RogueEssence.Menu
 {
-    public class TeachInfoMenu : InteractableMenu
+    public class TeachInfoMenu : SideScrollMenu
     {
+        public string itemId { get; private set; }
+
         MenuText SkillName;
         MenuText SkillCharges;
 
@@ -22,6 +24,7 @@ namespace RogueEssence.Menu
 
         public TeachInfoMenu(string itemNum)
         {
+            itemId = itemNum;
             Bounds = Rect.FromPoints(new Loc(16, 24), new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 72));
             
             ItemData itemData = DataManager.Instance.GetItem(itemNum);
@@ -32,7 +35,7 @@ namespace RogueEssence.Menu
 
             SkillName = new MenuText(skillEntry.GetColoredName(), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight));
             SkillCharges = new MenuText(Text.FormatKey("MENU_SKILLS_TOTAL_CHARGES", skillEntry.BaseCharges), new Loc(Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight));
-
+            
             SkillElement = new MenuText(Text.FormatKey("MENU_SKILLS_ELEMENT", elementEntry.GetIconName()), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE));
             SkillCategory = new MenuText(Text.FormatKey("MENU_SKILLS_CATEGORY", skillEntry.Data.Category.ToLocal()), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
 
@@ -48,6 +51,8 @@ namespace RogueEssence.Menu
 
             MenuDiv = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + LINE_HEIGHT),
                 Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
+
+            base.Initialize(Bounds.Top + (Bounds.Height) / 2);
         }
 
         public override IEnumerable<IMenuElement> GetElements()
@@ -79,6 +84,21 @@ namespace RogueEssence.Menu
                 GameManager.Instance.SE("Menu/Cancel");
                 MenuManager.Instance.RemoveMenu();
             }
+            else if (DirPressed(input, Dir8.Right))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                MenuManager.Instance.ReplaceMenu(new TeachWhomMenu(itemId, 0));
+            }
+            else if (DirPressed(input, Dir8.Left))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                MenuManager.Instance.ReplaceMenu(new TeachWhomMenu(itemId, (int)Math.Ceiling((double)DataManager.Instance.Save.ActiveTeam.Players.Count / 4) - 1));
+            }
+        }
+
+        private bool DirPressed(InputManager input, Dir8 dir)
+        {
+            return input.Direction == dir && input.PrevDirection != dir;
         }
     }
 }

--- a/RogueEssence/Menu/Items/TeachWhomMenu.cs
+++ b/RogueEssence/Menu/Items/TeachWhomMenu.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using RogueElements;
+using RogueEssence.Content;
+using RogueEssence.Data;
+using RogueEssence.Dungeon;
+
+namespace RogueEssence.Menu
+{
+    public class TeachWhomMenu : SideScrollMenu
+    {
+        public enum TeachState
+        {
+            CanLearn = 0,
+            CannotLearn = 1,
+            Learned = 2
+        }
+
+        public string itemId {get; private set;}
+        public string skillId {get; private set;}
+
+        int page;
+        
+        MenuText SkillName;
+        MenuText SkillCharges;
+
+        MenuDivider MenuDiv;
+        MenuText SkillElement;
+        MenuText SkillCategory;
+        MenuText SkillPower;
+        MenuText SkillHitRate;
+        MenuText SkillTargets;
+
+        MenuText MemberListTitle;
+
+        List<MenuText> MemberNames;
+        List<MenuText> MemberTeachState;
+
+        public TeachWhomMenu(string itemNum, int startPage)
+        {
+            page = startPage;
+            itemId = itemNum;
+            Bounds = Rect.FromPoints(new Loc(16, 24), new Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 72));
+
+            ItemData itemData = DataManager.Instance.GetItem(itemNum);
+            ItemIDState effect = itemData.ItemStates.GetWithDefault<ItemIDState>();
+            skillId = effect.ID;
+
+            SkillData skillEntry = DataManager.Instance.GetSkill(effect.ID);
+            ElementData elementEntry = DataManager.Instance.GetElement(skillEntry.Data.Element);
+
+            SkillName = new MenuText(skillEntry.GetColoredName(), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight));
+            SkillCharges = new MenuText(Text.FormatKey("MENU_SKILLS_TOTAL_CHARGES", skillEntry.BaseCharges), new Loc(Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight));
+            
+            SkillElement = new MenuText(Text.FormatKey("MENU_SKILLS_ELEMENT", elementEntry.GetIconName()), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE));
+            SkillCategory = new MenuText(Text.FormatKey("MENU_SKILLS_CATEGORY", skillEntry.Data.Category.ToLocal()), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
+
+            BasePowerState powerState = skillEntry.Data.SkillStates.GetWithDefault<BasePowerState>();
+            SkillPower = new MenuText(Text.FormatKey("MENU_SKILLS_POWER", (powerState != null ? powerState.Power.ToString() : "---")), new Loc(Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE));
+            SkillHitRate = new MenuText(Text.FormatKey("MENU_SKILLS_HIT_RATE", (skillEntry.Data.HitRate > -1 ? skillEntry.Data.HitRate + "%" : "---")), new Loc(Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 2));
+
+            SkillTargets = new MenuText(Text.FormatKey("MENU_SKILLS_RANGE", skillEntry.HitboxAction.GetDescription()), new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3));
+
+            MenuDiv = new MenuDivider(new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 3 + LINE_HEIGHT),
+                Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2);
+
+            MemberListTitle = new MenuText(Text.FormatKey("MENU_SKILLS_LEARN_LIST_TITLE", skillEntry.BaseCharges) + ":", new Loc(GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * 4));
+
+            MemberNames = new List<MenuText>();
+            MemberTeachState = new List<MenuText>();
+            for (int i=0; i<4; i++)
+            {
+                int y = GraphicsManager.MenuBG.TileHeight + VERT_SPACE * (5 + i);
+                MemberNames.Add(new MenuText("", new Loc(GraphicsManager.MenuBG.TileWidth * 2, y)));
+                MemberTeachState.Add(new MenuText("", new Loc(Bounds.Width / 2, y)));
+            }
+            UpdateMembers();
+            base.Initialize(Bounds.Top + (Bounds.Height) / 2);
+        }
+
+        private void UpdateMembers()
+        {
+            int startPos = page * 4;
+            EventedList<Character> team = DataManager.Instance.Save.ActiveTeam.Players;
+            for(int i=0; i < MemberNames.Count; i++)
+            {
+                int index = startPos + i;
+                if(index < team.Count)
+                {
+                    MemberNames[i].SetText(team[index].GetDisplayName(true));
+
+                    string stateText = "";
+                    TeachState state = GetTeachState(team[index]);
+                    switch (state)
+                    {
+                        case TeachState.CanLearn:
+                            stateText = "MENU_SKILLS_CAN_LEARN";
+                            break;
+                        case TeachState.CannotLearn:
+                            stateText = "MENU_SKILLS_CANNOT_LEARN";
+                            break;
+                        case TeachState.Learned:
+                            stateText = "MENU_SKILLS_LEARNED";
+                            break;
+                    }
+
+                    MemberTeachState[i].SetText(Text.FormatKey(stateText));
+                }
+                else
+                {
+                    MemberNames[i].SetText("");
+                    MemberTeachState[i].SetText("");
+                }
+            }
+        }
+
+        public TeachState GetTeachState(Character character)
+        {
+            BaseMonsterForm entry = DataManager.Instance.GetMonster(character.BaseForm.Species).Forms[character.BaseForm.Form];
+
+            //check for already knowing the skill
+            for (int ii = 0; ii < character.BaseSkills.Count; ii++)
+            {
+                if (character.BaseSkills[ii].SkillNum == skillId)
+                    return TeachState.Learned;
+            }
+
+            if (!DataManager.Instance.DataIndices[DataManager.DataType.Skill].Get(skillId).Released)
+                return TeachState.CannotLearn;
+
+            if (entry.CanLearnSkill(skillId))
+                return TeachState.CanLearn;
+            return TeachState.CannotLearn;
+        }
+
+        public override IEnumerable<IMenuElement> GetElements()
+        {
+            yield return SkillName;
+            yield return SkillCharges;
+
+            yield return SkillElement;
+            yield return SkillCategory;
+            yield return SkillPower;
+            yield return SkillHitRate;
+            yield return SkillTargets;
+
+            yield return MenuDiv;
+
+            yield return MemberListTitle;
+
+            for (int i = 0; i < MemberNames.Count; i++)
+            {
+                yield return MemberNames[i];
+                yield return MemberTeachState[i];
+            }
+        }
+
+        public override void Update(InputManager input)
+        {
+            Visible = true;
+            if (input.JustPressed(FrameInput.InputType.Menu))
+            {
+                GameManager.Instance.SE("Menu/Cancel");
+                MenuManager.Instance.ClearMenus();
+            }
+            else if (input.JustPressed(FrameInput.InputType.Cancel))
+            {
+                GameManager.Instance.SE("Menu/Cancel");
+                MenuManager.Instance.RemoveMenu();
+            }
+            else if (DirPressed(input, Dir8.Right))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                if (page == (int)Math.Ceiling((double)DataManager.Instance.Save.ActiveTeam.Players.Count / 4) - 1)
+                    MenuManager.Instance.ReplaceMenu(new TeachInfoMenu(itemId));
+                else
+                    MenuManager.Instance.ReplaceMenu(new TeachWhomMenu(itemId, page + 1));
+            }
+            else if (DirPressed(input, Dir8.Left))
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                if(page == 0)
+                    MenuManager.Instance.ReplaceMenu(new TeachInfoMenu(itemId));
+                else
+                    MenuManager.Instance.ReplaceMenu(new TeachWhomMenu(itemId, page - 1));
+            }
+        }
+
+        private bool DirPressed(InputManager input, Dir8 dir)
+        {
+            return input.Direction == dir && input.PrevDirection != dir;
+        }
+    }
+}

--- a/RogueEssence/Menu/SideScrollMenu.cs
+++ b/RogueEssence/Menu/SideScrollMenu.cs
@@ -9,10 +9,16 @@ namespace RogueEssence.Menu
         protected const int CURSOR_FLASH_TIME = 24;
 
         public ulong PrevTick;
+        public int arrowHeight;
 
         public void Initialize()
         {
+            Initialize(GraphicsManager.ScreenHeight / 2);
+        }
+        public void Initialize(int arrowH)
+        {
             PrevTick = GraphicsManager.TotalFrameTick % (ulong)FrameTick.FrameToTick(CURSOR_FLASH_TIME);
+            arrowHeight = arrowH;
         }
 
         public override void Draw(SpriteBatch spriteBatch)
@@ -24,8 +30,8 @@ namespace RogueEssence.Menu
             //draw cursor
             if (((GraphicsManager.TotalFrameTick - PrevTick) / (ulong)FrameTick.FrameToTick(CURSOR_FLASH_TIME / 2)) % 2 == 0 || Inactive)
             {
-                GraphicsManager.Cursor.DrawTile(spriteBatch, new Vector2(Bounds.X - GraphicsManager.Cursor.TileWidth, GraphicsManager.ScreenHeight / 2), 0, 0, Color.White, SpriteEffects.FlipHorizontally);
-                GraphicsManager.Cursor.DrawTile(spriteBatch, new Vector2(Bounds.End.X, GraphicsManager.ScreenHeight / 2), 0, 0);
+                GraphicsManager.Cursor.DrawTile(spriteBatch, new Vector2(Bounds.X - GraphicsManager.Cursor.TileWidth, arrowHeight), 0, 0, Color.White, SpriteEffects.FlipHorizontally);
+                GraphicsManager.Cursor.DrawTile(spriteBatch, new Vector2(Bounds.End.X, arrowHeight), 0, 0);
             }
 
         }


### PR DESCRIPTION
This PR implements the TeachWhomMenu class, a menu that displays the list of Pokémon in the current party and shows which of them can learn a specific move.
To access it you just need to press left or right inside TeachInfoMenu.

The required strings are added by https://github.com/audinowho/DumpAsset/pull/58