### PR TITLE
Adjust skill menu width for longer texts

### DIFF
--- a/RogueEssence/Menu/Skills/SkillMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillMenu.cs
@@ -27,7 +27,10 @@ namespace RogueEssence.Menu
 
             int menuWidthMin = 168;
             int menuWidthMax = GraphicsManager.ScreenWidth - 32;
-            int menuWidth = getMenuWidth(menuWidthMin, menuWidthMax, menuTitleText, openPlayers);
+            int chkWidth = 8;
+            int chargesWidth = 8 * 4;
+            int skillIndentWidth = 8 * 4;
+            int menuWidth = getMenuWidth(menuWidthMin, menuWidthMax, chkWidth, chargesWidth, skillIndentWidth, menuTitleText, openPlayers);
 
             MenuChoice[][] skills = new MenuChoice[openPlayers.Count][];
             for (int ii = 0; ii < openPlayers.Count; ii++)
@@ -45,11 +48,11 @@ namespace RogueEssence.Menu
                         bool disabled = (skill.Sealed || skill.Charges <= 0);
                         int index = jj;
                         MenuText chkText = new MenuText(chkString, new Loc(0, 1), disabled ? Color.Red : Color.White);
-                        MenuText menuText = new MenuText(skillString, new Loc(8, 1), disabled ? Color.Red : Color.White);
-                        MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - 8 * 4, 1), DirV.Up, DirH.Right, disabled ? Color.Red : Color.White);
+                        MenuText menuText = new MenuText(skillString, new Loc(chkWidth, 1), disabled ? Color.Red : Color.White);
+                        MenuText menuCharges = new MenuText(skillCharges, new Loc(menuWidth - chargesWidth, 1), DirV.Up, DirH.Right, disabled ? Color.Red : Color.White);
                         if (jj < Character.MAX_SKILL_SLOTS-1)
                         {
-                            MenuDivider div = new MenuDivider(new Loc(0, LINE_HEIGHT), menuWidth - 8 * 4);
+                            MenuDivider div = new MenuDivider(new Loc(0, LINE_HEIGHT), menuWidth - skillIndentWidth);
                             char_skills.Add(new MenuElementChoice(() => { choose(index); }, true, chkText, menuText, menuCharges, div));
                         }
                         else
@@ -110,15 +113,12 @@ namespace RogueEssence.Menu
                 MenuManager.Instance.AddMenu(new SkillChosenMenu(CurrentPage, choice), true);
         }
 
-        private int getMenuWidth(int min, int max, string title, List<Character> openPlayers)
+        private int getMenuWidth(int min, int max, int chkWidth, int chargesWidth, int skillIndent, string title, List<Character> openPlayers)
         {
             int menuWidth = min;
-            int extraSpaceWidth = 32; // seperation between skill/titel and charges/teamIndex
+            int extraSpace = 32; // seperation between skill/titel and charges/teamIndex
 
             // check for all skills if they exceed min
-            int chkTextLength = 8;
-            int chargesTextLength = 8 * 4;
-            int skillIndentation = chargesTextLength;
             foreach (Character character in openPlayers)
             {
                 foreach (BackReference<Skill> skillRef in character.Skills)
@@ -127,12 +127,9 @@ namespace RogueEssence.Menu
                     if (!String.IsNullOrEmpty(skill.SkillNum))
                     {
                         string skillName = DataManager.Instance.GetSkill(skill.SkillNum).GetColoredName();
-                        int skillNameLength = new MenuText(skillName, new Loc(0, 0)).GetTextLength();
-                        int skillRowLength = chkTextLength + chargesTextLength + skillIndentation + skillNameLength + extraSpaceWidth;
-                        if (skillRowLength > menuWidth)
-                        {
-                            menuWidth = skillRowLength;
-                        }
+                        int skillTextLength = new MenuText(skillName, new Loc(0, 0)).GetTextLength();
+                        int skillRowLength = skillIndent + chkWidth + skillTextLength + extraSpace + chargesWidth;
+                        menuWidth = Math.Max(skillRowLength, menuWidth);
                     }
                 }
             }
@@ -140,18 +137,8 @@ namespace RogueEssence.Menu
             // check if title exceeds min
             int titleTextLength = new MenuText(title, new Loc(0, 0)).GetTextLength();
             int teamIndexLength = 8 * 4;
-            int titleLength = titleTextLength + teamIndexLength + extraSpaceWidth;
-            if (titleLength > menuWidth)
-            {
-                menuWidth = titleLength;
-            }
-
-            if (menuWidth > max)
-            {
-                return max;
-            }
-
-            return menuWidth;
+            int titleLength = titleTextLength + teamIndexLength + extraSpace;
+            return Math.Min(max, Math.Max(titleLength, menuWidth));
         }
 
         protected override void ChoiceChanged()


### PR DESCRIPTION
This PR fixes:
- overlapping texts (see screenshot) in the skill menu if either playername or skill name is longer then usual.

![Unbenannt](https://github.com/RogueCollab/RogueEssence/assets/17873127/08aeb370-79d2-42e9-86af-8ab305eeee4a)
