### PR TITLE
Label system for ChoiceMenu

### DIFF
--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -3,6 +3,7 @@ using RogueElements;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
+using System.Linq;
 
 namespace RogueEssence.Menu
 {
@@ -19,6 +20,40 @@ namespace RogueEssence.Menu
             cursor = new MenuCursor(this, Dir4.Right);
             NonChoices = new List<IMenuElement>();
             Choices = new List<IChoosable>();
+        }
+
+        public virtual int GetChoiceIndexByLabel(string label)
+        {
+            return GetChoiceIndexesByLabel(label)[label];
+        }
+        public virtual Dictionary<string, int> GetChoiceIndexesByLabel(params string[] labels)
+        {
+            Dictionary<string, int> poss = new();
+            List<string> labelList = labels.ToList();
+            foreach (string label in labels)
+                poss.Add(label, -1);
+
+            for (int ii = 0; ii < Choices.Count; ii++)
+            {
+                bool found = false;
+                IChoosable choice = Choices[ii];
+                if (choice.HasLabel())
+                {
+                    for (int kk = 0; kk < labelList.Count; kk++)
+                    {
+                        string label = labelList[kk];
+                        if (choice.Label == label)
+                        {
+                            found = true;
+                            poss[label] = ii;
+                            labelList.RemoveAt(kk);
+                            break;
+                        }
+                    }
+                }
+                if (found && labelList.Count == 0) break;
+            }
+            return poss;
         }
 
         public override IEnumerable<IMenuElement> GetElements()

--- a/RogueEssence/Menu/Dialogue/SpeakerPortrait.cs
+++ b/RogueEssence/Menu/Dialogue/SpeakerPortrait.cs
@@ -8,7 +8,7 @@ namespace RogueEssence.Menu
 {
     public class SpeakerPortrait : IMenuElement
     {
-
+        public string Label { get; set; }
         public Loc Loc;
         public MonsterID Speaker;
         public EmoteStyle SpeakerEmotion;

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RogueEssence.Menu
+{
+    public interface ILabeled
+    {
+        public string Label { get; set; }
+        public bool HasLabel()
+        {
+            return string.IsNullOrEmpty(Label);
+        }
+    }
+}

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -8,7 +8,7 @@ namespace RogueEssence.Menu
 {
     public interface ILabeled
     {
-        public string Label { get; set; }
+        public string Label { get; }
         public bool HasLabel()
         {
             return !string.IsNullOrEmpty(Label);

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -11,7 +11,7 @@ namespace RogueEssence.Menu
         public string Label { get; set; }
         public bool HasLabel()
         {
-            return string.IsNullOrEmpty(Label);
+            return !string.IsNullOrEmpty(Label);
         }
     }
 }

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -52,7 +52,7 @@ namespace RogueEssence.Menu
             Choices.Clear();
             if (CharData.MAX_SKILL_SLOTS > 0)
             {
-                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SKILLS"), () =>
+                Choices.Add(new MenuTextChoice("SKILLS", Text.FormatKey("MENU_MAIN_SKILLS"), () =>
                 {
                     int mainIndex = DataManager.Instance.Save.ActiveTeam.LeaderIndex;
                     if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
@@ -64,34 +64,34 @@ namespace RogueEssence.Menu
                     MenuManager.Instance.AddMenu(new SkillMenu(mainIndex), false);
                 }));
             }
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice("INVENTORY", Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
 
             bool hasTactics = (DataManager.Instance.Save.ActiveTeam.Players.Count > 1);
             inReplay = (DataManager.Instance.CurrentReplay != null);
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
+            Choices.Add(new MenuTextChoice("TACTICS", Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice("TEAM", Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {
                 bool hasGround = DungeonScene.Instance.CanCheckGround();
-                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
+                Choices.Add(new MenuTextChoice("GROUND", Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
             }
 
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));
+            Choices.Add(new MenuTextChoice("OTHERS", Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));
             
             if (ZoneManager.Instance.InDevZone)
-                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));
+                Choices.Add(new MenuTextChoice("EDITOR_RETURN", Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));
             else if (!inReplay)
             {
                 if (((GameManager.Instance.CurrentScene == DungeonScene.Instance)) || DataManager.Instance.Save is RogueProgress)
-                    Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
+                    Choices.Add(new MenuTextChoice("REST", Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
                 else
-                    Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
+                    Choices.Add(new MenuTextChoice("SAVE", Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
             }
             else
             
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_TITLE"), () => { MenuManager.Instance.AddMenu(new ReplayMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
+            Choices.Add(new MenuTextChoice("REPLAY", Text.FormatKey("MENU_REPLAY_TITLE"), () => { MenuManager.Instance.AddMenu(new ReplayMenu(), false); }));
+            Choices.Add(new MenuTextChoice("EXIT", Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
         }
 
         public void SetupTitleAndSummary()

--- a/RogueEssence/Menu/MenuElements/DialogueText.cs
+++ b/RogueEssence/Menu/MenuElements/DialogueText.cs
@@ -10,6 +10,7 @@ namespace RogueEssence.Menu
 {
     public class DialogueText : IMenuElement
     {
+        public string Label { get; set; }
         public int LineHeight;
         public Rect Rect;
         public int CurrentCharIndex;

--- a/RogueEssence/Menu/MenuElements/DialogueText.cs
+++ b/RogueEssence/Menu/MenuElements/DialogueText.cs
@@ -40,8 +40,9 @@ namespace RogueEssence.Menu
         /// </summary>
         private int formattedTextLength;
 
-        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex, Color color)
+        public DialogueText(string label, string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex, Color color)
         {
+            Label = label;
             Rect = rect;
             LineHeight = lineHeight;
             CenterH = centerH;
@@ -52,14 +53,25 @@ namespace RogueEssence.Menu
             textColor = new List<(int idx, Color color)>();
             SetAndFormatText(text);
         }
+        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex, Color color)
+            : this("", text, rect, lineHeight, centerH, centerV, startIndex, color)
+        { }
 
-        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex)
-            : this(text, rect, lineHeight, centerH, centerV, startIndex, Color.White)
+        public DialogueText(string label, string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex)
+            : this(label, text, rect, lineHeight, centerH, centerV, startIndex, Color.White)
         {}
 
-        public DialogueText(string text, Rect rect, int lineHeight)
-            : this(text, rect, lineHeight, false, false, -1, Color.White)
+        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex)
+            : this("", text, rect, lineHeight, centerH, centerV, startIndex, Color.White)
         { }
+
+        public DialogueText(string label, string text, Rect rect, int lineHeight)
+            : this(label, text, rect, lineHeight, false, false, -1, Color.White)
+        { }
+        public DialogueText(string text, Rect rect, int lineHeight)
+            : this("", text, rect, lineHeight, false, false, -1, Color.White)
+        { }
+
 
         private static void formatText(List<(int idx, Color color)> colors, ref string text)
         {

--- a/RogueEssence/Menu/MenuElements/IMenuElement.cs
+++ b/RogueEssence/Menu/MenuElements/IMenuElement.cs
@@ -3,7 +3,7 @@ using RogueElements;
 
 namespace RogueEssence.Menu
 {
-    public interface IMenuElement
+    public interface IMenuElement : ILabeled
     {
         void Draw(SpriteBatch spriteBatch, Loc offset);
     }

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -20,13 +20,15 @@ namespace RogueEssence.Menu
 
         private bool hover;
         private bool click;
-        
-        protected MenuChoice(Action choiceAction, bool enabled)
+
+        protected MenuChoice(string label, Action choiceAction, bool enabled)
         {
+            Label = label;
             Bounds = new Rect();
             ChoiceAction = choiceAction;
             Enabled = enabled;
         }
+        protected MenuChoice(Action choiceAction, bool enabled) : this("", choiceAction, enabled) { }
 
         //chosen by clicking
         public void OnMouseState(bool clicked)

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -110,10 +110,14 @@ namespace RogueEssence.Menu
     {
         public MenuText Text;
 
-        public MenuTextChoice(string text, Action choiceAction) : this(text, choiceAction, true, Color.White) { }
+        public MenuTextChoice(string text, Action choiceAction) : this("", text, choiceAction, true, Color.White) { }
 
-        public MenuTextChoice(string text, Action choiceAction, bool enabled, Color color)
-            : base(choiceAction, enabled)
+        public MenuTextChoice(string label, string text, Action choiceAction) : this(label, text, choiceAction, true, Color.White) { }
+
+        public MenuTextChoice(string text, Action choiceAction, bool enabled, Color color) : this("", text, choiceAction, enabled, color) { }
+
+        public MenuTextChoice(string label, string text, Action choiceAction, bool enabled, Color color)
+            : base(label, choiceAction, enabled)
         {
             Text = new MenuText(text, new Loc(2, 1), color);
         }
@@ -127,8 +131,9 @@ namespace RogueEssence.Menu
     public class MenuElementChoice : MenuChoice
     {
         public List<IMenuElement> Elements;
-        
-        public MenuElementChoice(Action choiceAction, bool enabled, params IMenuElement[] elements) : base(choiceAction, enabled)
+
+        public MenuElementChoice(Action choiceAction, bool enabled, params IMenuElement[] elements) : this("", choiceAction, enabled, elements) { }
+        public MenuElementChoice(string label, Action choiceAction, bool enabled, params IMenuElement[] elements) : base(label, choiceAction, enabled)
         {
             ChoiceAction = choiceAction;
             Enabled = enabled;

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -4,6 +4,7 @@ using RogueElements;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
+using System.Linq;
 
 namespace RogueEssence.Menu
 {
@@ -138,6 +139,40 @@ namespace RogueEssence.Menu
         {
             foreach (IMenuElement element in Elements)
                 yield return element;
+        }
+
+        public virtual int GetChoiceIndexByLabel(string label)
+        {
+            return GetChoiceIndexesByLabel(label)[label];
+        }
+        public virtual Dictionary<string, int> GetChoiceIndexesByLabel(params string[] labels)
+        {
+            Dictionary<string, int> poss = new();
+            List<string> labelList = labels.ToList();
+            foreach (string label in labels)
+                poss.Add(label, -1);
+
+            for (int ii = 0; ii < Elements.Count; ii++)
+            {
+                bool found = false;
+                IMenuElement element = Elements[ii];
+                if (element.HasLabel())
+                {
+                    for (int kk = 0; kk < labelList.Count; kk++)
+                    {
+                        string label = labelList[kk];
+                        if (element.Label == label)
+                        {
+                            found = true;
+                            poss[label] = ii;
+                            labelList.RemoveAt(kk);
+                            break;
+                        }
+                    }
+                }
+                if (found && labelList.Count == 0) break;
+            }
+            return poss;
         }
     }
 }

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -9,6 +9,7 @@ namespace RogueEssence.Menu
 {
     public abstract class MenuChoice : IChoosable
     {
+        public string Label { get; set; }
         public Rect Bounds { get; set; }
 
         public Action ChoiceAction;

--- a/RogueEssence/Menu/MenuElements/MenuCursor.cs
+++ b/RogueEssence/Menu/MenuElements/MenuCursor.cs
@@ -17,13 +17,12 @@ namespace RogueEssence.Menu
         public Dir4 Direction;
 
         private IInteractable baseMenu;
-        public MenuCursor(IInteractable baseMenu)
+        public MenuCursor(IInteractable baseMenu) : this("", baseMenu, Dir4.Right) { }
+        public MenuCursor(string label, IInteractable baseMenu) : this(label, baseMenu, Dir4.Right) { }
+        public MenuCursor(IInteractable baseMenu, Dir4 dir) : this("", baseMenu, dir) { }
+        public MenuCursor(string label, IInteractable baseMenu, Dir4 dir)
         {
-            this.baseMenu = baseMenu;
-            this.Direction = Dir4.Right;
-        }
-        public MenuCursor(IInteractable baseMenu, Dir4 dir)
-        {
+            this.Label = label;
             this.baseMenu = baseMenu;
             this.Direction = dir;
         }
@@ -54,8 +53,6 @@ namespace RogueEssence.Menu
                         break;
                 }
             }
-
-
         }
     }
 }

--- a/RogueEssence/Menu/MenuElements/MenuCursor.cs
+++ b/RogueEssence/Menu/MenuElements/MenuCursor.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuCursor : IMenuElement
     {
+        public string Label { get; set; }
         protected const int CURSOR_FLASH_TIME = 24;
 
         public ulong PrevTick;

--- a/RogueEssence/Menu/MenuElements/MenuDigits.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDigits.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuDigits : IMenuElement
     {
+        public string Label { get; set; }
         public const int DIGIT_SPACE = 9;
 
         public int Amount;

--- a/RogueEssence/Menu/MenuElements/MenuDigits.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDigits.cs
@@ -16,11 +16,18 @@ namespace RogueEssence.Menu
         public Loc Loc;
 
         public MenuDigits(int digits, int minDigits, Loc loc)
-            : this(digits, minDigits, loc, Color.White)
+            : this("", digits, minDigits, loc, Color.White)
+        { }
+        public MenuDigits(string label, int digits, int minDigits, Loc loc)
+            : this(label, digits, minDigits, loc, Color.White)
         { }
 
         public MenuDigits(int digits, int minDigits, Loc loc, Color color)
+            : this("", digits, minDigits, loc, color)
+        { }
+        public MenuDigits(string label, int digits, int minDigits, Loc loc, Color color)
         {
+            Label = label;
             Amount = digits;
             MinDigits = minDigits;
             Loc = loc;

--- a/RogueEssence/Menu/MenuElements/MenuDirTex.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDirTex.cs
@@ -17,6 +17,7 @@ namespace RogueEssence.Menu
             BG
         }
 
+        public string Label { get; set; }
         public Loc Loc;
         public TexType Type;
         public AnimData Anim;

--- a/RogueEssence/Menu/MenuElements/MenuDirTex.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDirTex.cs
@@ -22,8 +22,10 @@ namespace RogueEssence.Menu
         public TexType Type;
         public AnimData Anim;
 
-        public MenuDirTex(Loc loc, TexType type, AnimData texture)
+        public MenuDirTex(Loc loc, TexType type, AnimData texture) : this("", loc, type, texture) { }
+        public MenuDirTex(string label, Loc loc, TexType type, AnimData texture)
         {
+            Label = label;
             Loc = loc;
             Type = type;
             Anim = texture;

--- a/RogueEssence/Menu/MenuElements/MenuDivider.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDivider.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuDivider : IMenuElement
     {
+        public string Label { get; set; }
         public int Length { get; set; }
         public Loc Loc { get; set; }
 

--- a/RogueEssence/Menu/MenuElements/MenuDivider.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDivider.cs
@@ -11,7 +11,8 @@ namespace RogueEssence.Menu
         public int Length { get; set; }
         public Loc Loc { get; set; }
 
-        public MenuDivider(Loc loc, int length)
+        public MenuDivider(Loc loc, int length) : this("", loc, length) { }
+        public MenuDivider(string label, Loc loc, int length)
         {
             Length = length;
             Loc = loc;

--- a/RogueEssence/Menu/MenuElements/MenuGraphic.cs
+++ b/RogueEssence/Menu/MenuElements/MenuGraphic.cs
@@ -17,8 +17,10 @@ namespace RogueEssence.Menu
         public GraphicType Type { get; set; }
         public Loc Texture { get; set; }
 
-        public MenuGraphic(Loc loc, GraphicType type, Loc texture)
+        public MenuGraphic(Loc loc, GraphicType type, Loc texture) : this("", loc, type, texture) { }
+        public MenuGraphic(string label, Loc loc, GraphicType type, Loc texture)
         {
+            Label = label;
             Loc = loc;
             Type = type;
             Texture = texture;

--- a/RogueEssence/Menu/MenuElements/MenuGraphic.cs
+++ b/RogueEssence/Menu/MenuElements/MenuGraphic.cs
@@ -12,6 +12,7 @@ namespace RogueEssence.Menu
             Button
         }
 
+        public string Label { get; set; }
         public Loc Loc { get; set; }
         public GraphicType Type { get; set; }
         public Loc Texture { get; set; }

--- a/RogueEssence/Menu/MenuElements/MenuPortrait.cs
+++ b/RogueEssence/Menu/MenuElements/MenuPortrait.cs
@@ -8,6 +8,7 @@ namespace RogueEssence.Menu
 {
     public class MenuPortrait : IMenuElement
     {
+        public string Label { get; set; }
         public Loc Loc;
         public MonsterID Speaker;
         public EmoteStyle SpeakerEmotion;

--- a/RogueEssence/Menu/MenuElements/MenuPortrait.cs
+++ b/RogueEssence/Menu/MenuElements/MenuPortrait.cs
@@ -13,11 +13,18 @@ namespace RogueEssence.Menu
         public MonsterID Speaker;
         public EmoteStyle SpeakerEmotion;
 
-        public MenuPortrait(Loc loc, MonsterID speaker) : this(loc, speaker, new EmoteStyle())
+        public MenuPortrait(Loc loc, MonsterID speaker) : this("", loc, speaker, new EmoteStyle())
         { }
 
-        public MenuPortrait(Loc loc, MonsterID speaker, EmoteStyle emote)
+        public MenuPortrait(string label, Loc loc, MonsterID speaker) : this(label, loc, speaker, new EmoteStyle())
+        { }
+
+        public MenuPortrait(Loc loc, MonsterID speaker, EmoteStyle emote) : this("", loc, speaker, emote)
+        { }
+
+        public MenuPortrait(string label, Loc loc, MonsterID speaker, EmoteStyle emote)
         {
+            Label = label;
             Loc = loc;
             Speaker = speaker;
             SpeakerEmotion = emote;

--- a/RogueEssence/Menu/MenuElements/MenuSetting.cs
+++ b/RogueEssence/Menu/MenuElements/MenuSetting.cs
@@ -29,13 +29,20 @@ namespace RogueEssence.Menu
 
         public MenuSetting() { }
 
-        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, Action choiceAction) : this(text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, defaultChoice, choiceAction) { }
+        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, Action choiceAction) : this("", text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, defaultChoice, choiceAction) { }
 
-        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this(text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+        public MenuSetting(string label, string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, Action choiceAction) : this(label, text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, defaultChoice, choiceAction) { }
 
-        public MenuSetting(string text, Color nrmColor, Color chgColor, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction)
+        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this("", text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+
+        public MenuSetting(string label, string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this(label, text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+
+        public MenuSetting(string text, Color nrmColor, Color chgColor, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this("", text, nrmColor, chgColor, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+
+        public MenuSetting(string label, string text, Color nrmColor, Color chgColor, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction)
             : this()
         {
+            Label = label;
             Bounds = new Rect();
             ChoiceAction = choiceAction;
             TotalChoices = totalChoices;

--- a/RogueEssence/Menu/MenuElements/MenuSetting.cs
+++ b/RogueEssence/Menu/MenuElements/MenuSetting.cs
@@ -8,6 +8,7 @@ namespace RogueEssence.Menu
 {
     public class MenuSetting : IChoosable
     {
+        public string Label { get; set; }
         public MenuText SettingName;
         public MenuText Setting;
 

--- a/RogueEssence/Menu/MenuElements/MenuStatBar.cs
+++ b/RogueEssence/Menu/MenuElements/MenuStatBar.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
+using System.Reflection.Emit;
 
 namespace RogueEssence.Menu
 {
@@ -13,9 +14,12 @@ namespace RogueEssence.Menu
         public Loc Loc { get; set; }
         public bool Shadow { get; set; }
 
-        public MenuStatBar(Loc loc, int length, Color color) : this(loc, length, color, true) { }
-        public MenuStatBar(Loc loc, int length, Color color, bool shadow)
+        public MenuStatBar(Loc loc, int length, Color color) : this("", loc, length, color, true) { }
+        public MenuStatBar(string label, Loc loc, int length, Color color) : this(label, loc, length, color, true) { }
+        public MenuStatBar(Loc loc, int length, Color color, bool shadow) : this("", loc, length, color, true) { }
+        public MenuStatBar(string label, Loc loc, int length, Color color, bool shadow)
         {
+            Label = label;
             Length = length;
             Loc = loc;
             Color = color;

--- a/RogueEssence/Menu/MenuElements/MenuStatBar.cs
+++ b/RogueEssence/Menu/MenuElements/MenuStatBar.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuStatBar : IMenuElement
     {
+        public string Label { get; set; }
         public int Length { get; set; }
         public Color Color { get; set; }
         public Loc Loc { get; set; }

--- a/RogueEssence/Menu/MenuElements/MenuText.cs
+++ b/RogueEssence/Menu/MenuElements/MenuText.cs
@@ -19,19 +19,33 @@ namespace RogueEssence.Menu
         private List<(int idx, Color color)> textColor;
 
         public MenuText(string text, Loc loc)
-            : this(text, loc, DirH.Left)
+            : this("", text, loc, DirH.Left)
+        { }
+        public MenuText(string label, string text, Loc loc)
+            : this(label, text, loc, DirH.Left)
         { }
 
         public MenuText(string text, Loc loc, Color color)
-            : this(text, loc, DirV.Up, DirH.Left, color)
+            : this("", text, loc, DirV.Up, DirH.Left, color)
+        { }
+        public MenuText(string label, string text, Loc loc, Color color)
+            : this(label, text, loc, DirV.Up, DirH.Left, color)
         { }
 
         public MenuText(string text, Loc loc, DirH align)
-            : this(text, loc, DirV.Up, align, Color.White)
+            : this("", text, loc, DirV.Up, align, Color.White)
+        { }
+
+        public MenuText(string label, string text, Loc loc, DirH align)
+            : this(label, text, loc, DirV.Up, align, Color.White)
         { }
 
         public MenuText(string text, Loc loc, DirV alignV, DirH alignH, Color color)
+            : this("", text, loc, alignV, alignH, color)
+        { }
+        public MenuText(string label, string text, Loc loc, DirV alignV, DirH alignH, Color color)
         {
+            Label = label;
             Loc = loc;
             AlignV = alignV;
             AlignH = alignH;

--- a/RogueEssence/Menu/MenuElements/MenuText.cs
+++ b/RogueEssence/Menu/MenuElements/MenuText.cs
@@ -10,6 +10,7 @@ namespace RogueEssence.Menu
 {
     public class MenuText : IMenuElement
     {
+        public string Label { get; set; }
         public string Text { get; private set; }
         public Color Color;
         public DirV AlignV;

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using RogueElements;
 using RogueEssence.Content;
 
@@ -151,6 +152,45 @@ namespace RogueEssence.Menu
         public void ImportTotalChoices(IChoosable[] choices)
         {
             TotalChoices = SortIntoPages(choices, SpacesPerPage);
+        }
+
+        public override int GetChoiceIndexByLabel(string label)
+        {
+            return GetChoiceIndexesByLabel(label)[label];
+        }
+        public override Dictionary<string, int> GetChoiceIndexesByLabel(params string[] labels)
+        {
+            Dictionary<string, int> poss = new();
+            List<string> labelList = labels.ToList();
+            foreach (string label in labels)
+                poss.Add(label, -1);
+
+            for (int ii = 0; ii < TotalChoices.Length; ii++)
+            {
+                bool found = false;
+                IChoosable[] page = TotalChoices[ii];
+                for (int jj = 0; jj < TotalChoices.Length; jj++)
+                {
+                    IChoosable choice = page[jj];
+                    if (choice.HasLabel())
+                    {
+                        for (int kk = 0; kk < labelList.Count; kk++)
+                        {
+                            string label = labelList[kk];
+                            if(choice.Label == label)
+                            {
+                                found = true;
+                                poss[label] = ii * SpacesPerPage + jj;
+                                labelList.RemoveAt(kk);
+                                break;
+                            }
+                        }
+                    }
+                    if (found) break;
+                }
+                if (found && labelList.Count == 0) break;
+            }
+            return poss;
         }
     }
 }

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -152,6 +152,7 @@ namespace RogueEssence.Menu
         public void ImportTotalChoices(IChoosable[] choices)
         {
             TotalChoices = SortIntoPages(choices, SpacesPerPage);
+            SetPage(CurrentPage);
         }
 
         public override int GetChoiceIndexByLabel(string label)

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -169,7 +169,7 @@ namespace RogueEssence.Menu
             {
                 bool found = false;
                 IChoosable[] page = TotalChoices[ii];
-                for (int jj = 0; jj < TotalChoices.Length; jj++)
+                for (int jj = 0; jj < TotalChoices[ii].Length; jj++)
                 {
                     IChoosable choice = page[jj];
                     if (choice.HasLabel())

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -135,5 +135,22 @@ namespace RogueEssence.Menu
             int index = totalIndex % SpacesPerPage;
             return TotalChoices[page][index];
         }
+
+        public List<IChoosable> ExportTotalChoices()
+        {
+            List<IChoosable> allChoices = new();
+            foreach (IChoosable[] page in TotalChoices)
+                foreach (IChoosable choice in page)
+                    allChoices.Add(choice);
+            return allChoices;
+        }
+        public void ImportTotalChoices(List<IChoosable> choices)
+        {
+            ImportTotalChoices(choices.ToArray());
+        }
+        public void ImportTotalChoices(IChoosable[] choices)
+        {
+            TotalChoices = SortIntoPages(choices, SpacesPerPage);
+        }
     }
 }

--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -22,10 +22,10 @@ namespace RogueEssence.Menu
         public void SetupChoices()
         {
             Choices.Clear();
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice("MSG_LOG", Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
+            Choices.Add(new MenuTextChoice("SETTINGS", Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
+            Choices.Add(new MenuTextChoice("KEYBOARD", Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice("GAMEPAD", Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
         }
 
         public void InitMenu()


### PR DESCRIPTION
- `ILabeled` contains the `Label` property and the `HasLabel` method.
- `IMenuElement` implements `ILabeled` (getting some work done in advance, here).
- `ChoiceMenu` gains a `GetChoiceIndexesByLabel` method and a `GetChoiceIndexByLabel` one that look specific labels up inside its list of choices. Any missing label will have -1 as its return position.
- `MultiPageMenu` has its own `GetChoiceIndexesByLabel` and `GetChoiceIndexByLabel` methods that work better with its different structure.
- `MultiPageMenu` has two `ImportTotalChoices` and an `ExportTotalChoices` method. Modders are expected to call ExportTotalChoices, do what they need to do in the list it returns, and then use ImportTotalChoices to update the menu with their changes.
- `MenuElementChoice` has its own `GetChoiceIndexesByLabel` and `int GetChoiceIndexByLabel` methods as well.
- `MainMenu` and `OthersMenu` choices are labeled. It'll be good enough for now.