### PR TITLE
OnAddMenu service event and labels for menus

### DIFF
--- a/RogueEssence/Dungeon/DSceneMap.cs
+++ b/RogueEssence/Dungeon/DSceneMap.cs
@@ -991,7 +991,7 @@ namespace RogueEssence.Dungeon
             else
             {
                 yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.SetDialogue(Text.FormatKey("DLG_TEAM_FULL")));
-                yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(new TeamMenu(true)));
+                yield return CoroutineManager.Instance.StartCoroutine(MenuManager.Instance.ProcessMenuCoroutine(new TeamMenu(MenuLabel.TEAM_SENDHOME.ToString(), true)));
             }
         }
         

--- a/RogueEssence/Lua/LuaEngine.cs
+++ b/RogueEssence/Lua/LuaEngine.cs
@@ -1883,6 +1883,8 @@ namespace RogueEssence.Script
         {
             DiagManager.Instance.LogInfo("LuaEngine.OnAddMenu()...");
             m_scrsvc.Publish(EServiceEvents.AddMenu.ToString(), menu);
+            if (menu is InteractableMenu interactable && ((ILabeled)interactable).HasLabel())
+                DiagManager.Instance.LogInfo("Menu label is: " + interactable.Label);
         }
 
         public void OnNewGame()

--- a/RogueEssence/Lua/LuaEngine.cs
+++ b/RogueEssence/Lua/LuaEngine.cs
@@ -291,6 +291,7 @@ namespace RogueEssence.Script
             Update,
             SaveData,
             LoadSavedData,
+            AddMenu,
 
             MusicChange,
             GroundEntityInteract,
@@ -1873,6 +1874,15 @@ namespace RogueEssence.Script
         {
             DiagManager.Instance.LogInfo("LuaEngine.OnMenuButtonPressed()...");
             yield return CoroutineManager.Instance.StartCoroutine(m_scrsvc.PublishCoroutine(EServiceEvents.MenuButtonPressed.ToString()));
+        }
+
+        /// <summary>
+        /// Called when a menu is about to be added to the menu stack!
+        /// </summary>
+        public void OnAddMenu(IInteractable menu)
+        {
+            DiagManager.Instance.LogInfo("LuaEngine.OnAddMenu()...");
+            m_scrsvc.Publish(EServiceEvents.AddMenu.ToString(), menu);
         }
 
         public void OnNewGame()

--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -3,6 +3,7 @@ using RogueElements;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
+using System.Linq;
 
 namespace RogueEssence.Menu
 {
@@ -19,6 +20,40 @@ namespace RogueEssence.Menu
             cursor = new MenuCursor(this, Dir4.Right);
             NonChoices = new List<IMenuElement>();
             Choices = new List<IChoosable>();
+        }
+
+        public virtual int GetChoiceIndexByLabel(string label)
+        {
+            return GetChoiceIndexesByLabel(label)[label];
+        }
+        public virtual Dictionary<string, int> GetChoiceIndexesByLabel(params string[] labels)
+        {
+            Dictionary<string, int> poss = new();
+            List<string> labelList = labels.ToList();
+            foreach (string label in labels)
+                poss.Add(label, -1);
+
+            for (int ii = 0; ii < Choices.Count; ii++)
+            {
+                bool found = false;
+                IChoosable choice = Choices[ii];
+                if (choice.HasLabel())
+                {
+                    for (int kk = 0; kk < labelList.Count; kk++)
+                    {
+                        string label = labelList[kk];
+                        if (choice.Label == label)
+                        {
+                            found = true;
+                            poss[label] = ii;
+                            labelList.RemoveAt(kk);
+                            break;
+                        }
+                    }
+                }
+                if (found && labelList.Count == 0) break;
+            }
+            return poss;
         }
 
         public override IEnumerable<IMenuElement> GetElements()

--- a/RogueEssence/Menu/Dialogue/SpeakerPortrait.cs
+++ b/RogueEssence/Menu/Dialogue/SpeakerPortrait.cs
@@ -8,7 +8,7 @@ namespace RogueEssence.Menu
 {
     public class SpeakerPortrait : IMenuElement
     {
-
+        public string Label { get; set; }
         public Loc Loc;
         public MonsterID Speaker;
         public EmoteStyle SpeakerEmotion;

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -32,6 +32,8 @@ namespace RogueEssence.Menu
         GROUND,
         GROUND_ITEM,
         GROUND_TILE,
-        OTHERS
+        OTHERS,
+        REST,
+        SAVE
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RogueEssence.Menu
+{
+    public interface ILabeled
+    {
+        public string Label { get; set; }
+        public bool HasLabel()
+        {
+            return string.IsNullOrEmpty(Label);
+        }
+    }
+}

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -13,6 +13,10 @@ namespace RogueEssence.Menu
         {
             return !string.IsNullOrEmpty(Label);
         }
+        public bool LabelContains(string substr)
+        {
+            return HasLabel() && Label.Contains(substr);
+        }
     }
 
     public enum MenuLabel

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -20,5 +20,6 @@ namespace RogueEssence.Menu
         MAIN,
         SKILLS,
         INVENTORY,
+        INVENTORY_REPLACE,
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -34,6 +34,10 @@ namespace RogueEssence.Menu
         GROUND_TILE,
         OTHERS,
         REST,
-        SAVE
+        SAVE,
+        MSG_LOG,
+        SETTINGS,
+        KEYBOARD,
+        GAMEPAD
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -14,4 +14,10 @@ namespace RogueEssence.Menu
             return !string.IsNullOrEmpty(Label);
         }
     }
+
+    public enum MenuLabel
+    {
+        SKILLS,
+        INVENTORY,
+    }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -24,6 +24,7 @@ namespace RogueEssence.Menu
         TACTICS,
         TEAM,
         TEAM_SWITCH,
-        TEAM_SENDHOME
+        TEAM_SENDHOME,
+        OTHERS
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -21,5 +21,6 @@ namespace RogueEssence.Menu
         SKILLS,
         INVENTORY,
         INVENTORY_REPLACE,
+        TACTICS
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -8,7 +8,7 @@ namespace RogueEssence.Menu
 {
     public interface ILabeled
     {
-        public string Label { get; set; }
+        public string Label { get; }
         public bool HasLabel()
         {
             return !string.IsNullOrEmpty(Label);

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -11,7 +11,7 @@ namespace RogueEssence.Menu
         public string Label { get; set; }
         public bool HasLabel()
         {
-            return string.IsNullOrEmpty(Label);
+            return !string.IsNullOrEmpty(Label);
         }
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -21,6 +21,7 @@ namespace RogueEssence.Menu
         SKILLS,
         INVENTORY,
         INVENTORY_REPLACE,
-        TACTICS
+        TACTICS,
+        TEAM
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -22,6 +22,8 @@ namespace RogueEssence.Menu
         INVENTORY,
         INVENTORY_REPLACE,
         TACTICS,
-        TEAM
+        TEAM,
+        TEAM_SWITCH,
+        TEAM_SENDHOME
     }
 }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -17,6 +17,7 @@ namespace RogueEssence.Menu
 
     public enum MenuLabel
     {
+        MAIN,
         SKILLS,
         INVENTORY,
     }

--- a/RogueEssence/Menu/ILabeled.cs
+++ b/RogueEssence/Menu/ILabeled.cs
@@ -25,6 +25,9 @@ namespace RogueEssence.Menu
         TEAM,
         TEAM_SWITCH,
         TEAM_SENDHOME,
+        GROUND,
+        GROUND_ITEM,
+        GROUND_TILE,
         OTHERS
     }
 }

--- a/RogueEssence/Menu/InteractableMenu.cs
+++ b/RogueEssence/Menu/InteractableMenu.cs
@@ -3,7 +3,7 @@ using RogueEssence.Content;
 
 namespace RogueEssence.Menu
 {
-    public abstract class InteractableMenu : MenuBase, IInteractable
+    public abstract class InteractableMenu : MenuBase, IInteractable, ILabeled
     {
         const int INPUT_WAIT = 30;
         const int INPUT_GAP = 6;
@@ -14,6 +14,8 @@ namespace RogueEssence.Menu
             set;
         }
         public bool BlockPrevious { get; set; }
+
+        public virtual string Label { get; set; } = "";
 
         public abstract void Update(InputManager input);
 

--- a/RogueEssence/Menu/InteractableMenu.cs
+++ b/RogueEssence/Menu/InteractableMenu.cs
@@ -15,7 +15,7 @@ namespace RogueEssence.Menu
         }
         public bool BlockPrevious { get; set; }
 
-        public virtual string Label { get; set; } = "";
+        public virtual string Label { get; protected set; } = "";
 
         public abstract void Update(InputManager input);
 

--- a/RogueEssence/Menu/Items/ItemChosenMenu.cs
+++ b/RogueEssence/Menu/Items/ItemChosenMenu.cs
@@ -236,7 +236,7 @@ namespace RogueEssence.Menu
 
         private void SwapAction()
         {
-            MenuManager.Instance.AddMenu(new ItemMenu(slot), false);
+            MenuManager.Instance.AddMenu(new ItemMenu(MenuLabel.INVENTORY_REPLACE.ToString(), slot), false);
         }
         private void GiveAction()
         {

--- a/RogueEssence/Menu/Items/ItemMenu.cs
+++ b/RogueEssence/Menu/Items/ItemMenu.cs
@@ -23,7 +23,7 @@ namespace RogueEssence.Menu
 
         //-2 for no replace slot, -1 for replace with ground, positive numbers for replace held team index's item
         public ItemMenu() : this(-2) { }
-        public ItemMenu(int replaceSlot) : this("INVENTORY", replaceSlot) { }
+        public ItemMenu(int replaceSlot) : this(MenuLabel.INVENTORY.ToString(), replaceSlot) { }
         public ItemMenu(string label) : this(label, -2) { }
         public ItemMenu(string label, int replaceSlot)
         {

--- a/RogueEssence/Menu/Items/ItemMenu.cs
+++ b/RogueEssence/Menu/Items/ItemMenu.cs
@@ -23,8 +23,11 @@ namespace RogueEssence.Menu
 
         //-2 for no replace slot, -1 for replace with ground, positive numbers for replace held team index's item
         public ItemMenu() : this(-2) { }
-        public ItemMenu(int replaceSlot)
+        public ItemMenu(int replaceSlot) : this("INVENTORY", replaceSlot) { }
+        public ItemMenu(string label) : this(label, -2) { }
+        public ItemMenu(string label, int replaceSlot)
         {
+            this.Label = label;
             this.replaceSlot = replaceSlot;
             
             bool enableHeld = (replaceSlot == -2);

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -79,7 +79,7 @@ namespace RogueEssence.Menu
                 Choices.Add(new MenuTextChoice("GROUND", Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
             }
 
-            Choices.Add(new MenuTextChoice("OTHERS", Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.OTHERS.ToString(), Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));
             
             if (ZoneManager.Instance.InDevZone)
                 Choices.Add(new MenuTextChoice("EDITOR_RETURN", Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -52,7 +52,7 @@ namespace RogueEssence.Menu
             Choices.Clear();
             if (CharData.MAX_SKILL_SLOTS > 0)
             {
-                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SKILLS"), () =>
+                Choices.Add(new MenuTextChoice("SKILLS", Text.FormatKey("MENU_MAIN_SKILLS"), () =>
                 {
                     int mainIndex = DataManager.Instance.Save.ActiveTeam.LeaderIndex;
                     if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
@@ -64,34 +64,34 @@ namespace RogueEssence.Menu
                     MenuManager.Instance.AddMenu(new SkillMenu(mainIndex), false);
                 }));
             }
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice("INVENTORY", Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
 
             bool hasTactics = (DataManager.Instance.Save.ActiveTeam.Players.Count > 1);
             inReplay = (DataManager.Instance.CurrentReplay != null);
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
+            Choices.Add(new MenuTextChoice("TACTICS", Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice("TEAM", Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {
                 bool hasGround = DungeonScene.Instance.CanCheckGround();
-                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
+                Choices.Add(new MenuTextChoice("GROUND", Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
             }
 
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));
+            Choices.Add(new MenuTextChoice("OTHERS", Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));
             
             if (ZoneManager.Instance.InDevZone)
-                Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));
+                Choices.Add(new MenuTextChoice("EDITOR_RETURN", Text.FormatKey("MENU_MAIN_EDITOR_RETURN"), ReturnToEditorAction));
             else if (!inReplay)
             {
                 if (((GameManager.Instance.CurrentScene == DungeonScene.Instance)) || DataManager.Instance.Save is RogueProgress)
-                    Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
+                    Choices.Add(new MenuTextChoice("REST", Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
                 else
-                    Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
+                    Choices.Add(new MenuTextChoice("SAVE", Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
             }
             else
             
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_REPLAY_TITLE"), () => { MenuManager.Instance.AddMenu(new ReplayMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
+            Choices.Add(new MenuTextChoice("REPLAY", Text.FormatKey("MENU_REPLAY_TITLE"), () => { MenuManager.Instance.AddMenu(new ReplayMenu(), false); }));
+            Choices.Add(new MenuTextChoice("EXIT", Text.FormatKey("MENU_EXIT"), MenuManager.Instance.RemoveMenu));
         }
 
         public void SetupTitleAndSummary()

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -33,6 +33,7 @@ namespace RogueEssence.Menu
         public MainMenu() : this(MenuLabel.MAIN.ToString()) { }
         public MainMenu(string label)
         {
+            Label = label;
             Choices = new List<MenuTextChoice>();
             TitleElements = new List<IMenuElement>();
             SummaryElements = new List<IMenuElement>();

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -71,7 +71,7 @@ namespace RogueEssence.Menu
             bool hasTactics = (DataManager.Instance.Save.ActiveTeam.Players.Count > 1);
             inReplay = (DataManager.Instance.CurrentReplay != null);
             Choices.Add(new MenuTextChoice(MenuLabel.TACTICS.ToString(), Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
-            Choices.Add(new MenuTextChoice("TEAM", Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.TEAM.ToString(), Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -9,6 +9,7 @@ using System;
 using KeraLua;
 using RogueEssence.Ground;
 using RogueEssence.Script;
+using System.Reflection.Emit;
 
 namespace RogueEssence.Menu
 {
@@ -29,8 +30,8 @@ namespace RogueEssence.Menu
         public Rect TitleMenuBounds { get; set; }
         public SummaryMenu SummaryMenu { get; set; }
         public Rect SummaryMenuBounds { get; set; }
-        public MainMenu(string label) : this() { Label = label; }
-        public MainMenu()
+        public MainMenu() : this(MenuLabel.MAIN.ToString()) { }
+        public MainMenu(string label)
         {
             Choices = new List<MenuTextChoice>();
             TitleElements = new List<IMenuElement>();

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -76,7 +76,7 @@ namespace RogueEssence.Menu
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
             {
                 bool hasGround = DungeonScene.Instance.CanCheckGround();
-                Choices.Add(new MenuTextChoice("GROUND", Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
+                Choices.Add(new MenuTextChoice(MenuLabel.GROUND.ToString(), Text.FormatKey("MENU_GROUND_TITLE"), checkGround, (hasGround && !inReplay), (hasGround && !inReplay) ? Color.White : Color.Red));
             }
 
             Choices.Add(new MenuTextChoice(MenuLabel.OTHERS.ToString(), Text.FormatKey("MENU_OTHERS_TITLE"), () => { MenuManager.Instance.AddMenu(OthersMenu.InitDefaultOthersMenu(), false); }));

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -54,7 +54,7 @@ namespace RogueEssence.Menu
             Choices.Clear();
             if (CharData.MAX_SKILL_SLOTS > 0)
             {
-                Choices.Add(new MenuTextChoice("SKILLS", Text.FormatKey("MENU_MAIN_SKILLS"), () =>
+                Choices.Add(new MenuTextChoice(MenuLabel.SKILLS.ToString(), Text.FormatKey("MENU_MAIN_SKILLS"), () =>
                 {
                     int mainIndex = DataManager.Instance.Save.ActiveTeam.LeaderIndex;
                     if (GameManager.Instance.CurrentScene == DungeonScene.Instance)
@@ -66,11 +66,11 @@ namespace RogueEssence.Menu
                     MenuManager.Instance.AddMenu(new SkillMenu(mainIndex), false);
                 }));
             }
-            Choices.Add(new MenuTextChoice("INVENTORY", Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice(MenuLabel.INVENTORY.ToString(), Text.FormatKey("MENU_MAIN_INVENTORY"), () => { MenuManager.Instance.AddMenu(new ItemMenu(), false); }, invEnabled, invEnabled ? Color.White : Color.Red));
 
             bool hasTactics = (DataManager.Instance.Save.ActiveTeam.Players.Count > 1);
             inReplay = (DataManager.Instance.CurrentReplay != null);
-            Choices.Add(new MenuTextChoice("TACTICS", Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
+            Choices.Add(new MenuTextChoice(MenuLabel.TACTICS.ToString(), Text.FormatKey("MENU_TACTICS_TITLE"), () => { MenuManager.Instance.AddMenu(new TacticsMenu(), false); }, (hasTactics && !inReplay), (hasTactics && !inReplay) ? Color.White : Color.Red));
             Choices.Add(new MenuTextChoice("TEAM", Text.FormatKey("MENU_TEAM_TITLE"), () => { MenuManager.Instance.AddMenu(new TeamMenu(false), false); }));
 
             if (GameManager.Instance.CurrentScene == DungeonScene.Instance)

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -19,7 +19,7 @@ namespace RogueEssence.Menu
         private bool inReplay;
 
         MenuText menuTimer;
-        
+
         public List<MenuTextChoice> Choices { get; set; }
         public List<IMenuElement> TitleElements { get; set; }
         public List<IMenuElement> SummaryElements { get; set; }
@@ -29,6 +29,7 @@ namespace RogueEssence.Menu
         public Rect TitleMenuBounds { get; set; }
         public SummaryMenu SummaryMenu { get; set; }
         public Rect SummaryMenuBounds { get; set; }
+        public MainMenu(string label) : this() { Label = label; }
         public MainMenu()
         {
             Choices = new List<MenuTextChoice>();

--- a/RogueEssence/Menu/MainMenu.cs
+++ b/RogueEssence/Menu/MainMenu.cs
@@ -86,9 +86,9 @@ namespace RogueEssence.Menu
             else if (!inReplay)
             {
                 if (((GameManager.Instance.CurrentScene == DungeonScene.Instance)) || DataManager.Instance.Save is RogueProgress)
-                    Choices.Add(new MenuTextChoice("REST", Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
+                    Choices.Add(new MenuTextChoice(MenuLabel.REST.ToString(), Text.FormatKey("MENU_REST_TITLE"), () => { MenuManager.Instance.AddMenu(new RestMenu(), false); }));
                 else
-                    Choices.Add(new MenuTextChoice("SAVE", Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
+                    Choices.Add(new MenuTextChoice(MenuLabel.SAVE.ToString(), Text.FormatKey("MENU_MAIN_SAVE"), SaveAction));
             }
             else
             

--- a/RogueEssence/Menu/MenuElements/DialogueText.cs
+++ b/RogueEssence/Menu/MenuElements/DialogueText.cs
@@ -10,6 +10,7 @@ namespace RogueEssence.Menu
 {
     public class DialogueText : IMenuElement
     {
+        public string Label { get; set; }
         public int LineHeight;
         public Rect Rect;
         public int CurrentCharIndex;

--- a/RogueEssence/Menu/MenuElements/DialogueText.cs
+++ b/RogueEssence/Menu/MenuElements/DialogueText.cs
@@ -40,8 +40,9 @@ namespace RogueEssence.Menu
         /// </summary>
         private int formattedTextLength;
 
-        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex, Color color)
+        public DialogueText(string label, string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex, Color color)
         {
+            Label = label;
             Rect = rect;
             LineHeight = lineHeight;
             CenterH = centerH;
@@ -52,14 +53,25 @@ namespace RogueEssence.Menu
             textColor = new List<(int idx, Color color)>();
             SetAndFormatText(text);
         }
+        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex, Color color)
+            : this("", text, rect, lineHeight, centerH, centerV, startIndex, color)
+        { }
 
-        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex)
-            : this(text, rect, lineHeight, centerH, centerV, startIndex, Color.White)
+        public DialogueText(string label, string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex)
+            : this(label, text, rect, lineHeight, centerH, centerV, startIndex, Color.White)
         {}
 
-        public DialogueText(string text, Rect rect, int lineHeight)
-            : this(text, rect, lineHeight, false, false, -1, Color.White)
+        public DialogueText(string text, Rect rect, int lineHeight, bool centerH, bool centerV, int startIndex)
+            : this("", text, rect, lineHeight, centerH, centerV, startIndex, Color.White)
         { }
+
+        public DialogueText(string label, string text, Rect rect, int lineHeight)
+            : this(label, text, rect, lineHeight, false, false, -1, Color.White)
+        { }
+        public DialogueText(string text, Rect rect, int lineHeight)
+            : this("", text, rect, lineHeight, false, false, -1, Color.White)
+        { }
+
 
         private static void formatText(List<(int idx, Color color)> colors, ref string text)
         {

--- a/RogueEssence/Menu/MenuElements/IMenuElement.cs
+++ b/RogueEssence/Menu/MenuElements/IMenuElement.cs
@@ -3,7 +3,7 @@ using RogueElements;
 
 namespace RogueEssence.Menu
 {
-    public interface IMenuElement
+    public interface IMenuElement : ILabeled
     {
         void Draw(SpriteBatch spriteBatch, Loc offset);
     }

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -20,13 +20,15 @@ namespace RogueEssence.Menu
 
         private bool hover;
         private bool click;
-        
-        protected MenuChoice(Action choiceAction, bool enabled)
+
+        protected MenuChoice(string label, Action choiceAction, bool enabled)
         {
+            Label = label;
             Bounds = new Rect();
             ChoiceAction = choiceAction;
             Enabled = enabled;
         }
+        protected MenuChoice(Action choiceAction, bool enabled) : this("", choiceAction, enabled) { }
 
         //chosen by clicking
         public void OnMouseState(bool clicked)

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -110,10 +110,14 @@ namespace RogueEssence.Menu
     {
         public MenuText Text;
 
-        public MenuTextChoice(string text, Action choiceAction) : this(text, choiceAction, true, Color.White) { }
+        public MenuTextChoice(string text, Action choiceAction) : this("", text, choiceAction, true, Color.White) { }
 
-        public MenuTextChoice(string text, Action choiceAction, bool enabled, Color color)
-            : base(choiceAction, enabled)
+        public MenuTextChoice(string label, string text, Action choiceAction) : this(label, text, choiceAction, true, Color.White) { }
+
+        public MenuTextChoice(string text, Action choiceAction, bool enabled, Color color) : this("", text, choiceAction, enabled, color) { }
+
+        public MenuTextChoice(string label, string text, Action choiceAction, bool enabled, Color color)
+            : base(label, choiceAction, enabled)
         {
             Text = new MenuText(text, new Loc(2, 1), color);
         }
@@ -127,8 +131,9 @@ namespace RogueEssence.Menu
     public class MenuElementChoice : MenuChoice
     {
         public List<IMenuElement> Elements;
-        
-        public MenuElementChoice(Action choiceAction, bool enabled, params IMenuElement[] elements) : base(choiceAction, enabled)
+
+        public MenuElementChoice(Action choiceAction, bool enabled, params IMenuElement[] elements) : this("", choiceAction, enabled, elements) { }
+        public MenuElementChoice(string label, Action choiceAction, bool enabled, params IMenuElement[] elements) : base(label, choiceAction, enabled)
         {
             ChoiceAction = choiceAction;
             Enabled = enabled;

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -4,6 +4,7 @@ using RogueElements;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
+using System.Linq;
 
 namespace RogueEssence.Menu
 {
@@ -138,6 +139,40 @@ namespace RogueEssence.Menu
         {
             foreach (IMenuElement element in Elements)
                 yield return element;
+        }
+
+        public virtual int GetChoiceIndexByLabel(string label)
+        {
+            return GetChoiceIndexesByLabel(label)[label];
+        }
+        public virtual Dictionary<string, int> GetChoiceIndexesByLabel(params string[] labels)
+        {
+            Dictionary<string, int> poss = new();
+            List<string> labelList = labels.ToList();
+            foreach (string label in labels)
+                poss.Add(label, -1);
+
+            for (int ii = 0; ii < Elements.Count; ii++)
+            {
+                bool found = false;
+                IMenuElement element = Elements[ii];
+                if (element.HasLabel())
+                {
+                    for (int kk = 0; kk < labelList.Count; kk++)
+                    {
+                        string label = labelList[kk];
+                        if (element.Label == label)
+                        {
+                            found = true;
+                            poss[label] = ii;
+                            labelList.RemoveAt(kk);
+                            break;
+                        }
+                    }
+                }
+                if (found && labelList.Count == 0) break;
+            }
+            return poss;
         }
     }
 }

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -9,6 +9,7 @@ namespace RogueEssence.Menu
 {
     public abstract class MenuChoice : IChoosable
     {
+        public string Label { get; set; }
         public Rect Bounds { get; set; }
 
         public Action ChoiceAction;

--- a/RogueEssence/Menu/MenuElements/MenuCursor.cs
+++ b/RogueEssence/Menu/MenuElements/MenuCursor.cs
@@ -17,13 +17,12 @@ namespace RogueEssence.Menu
         public Dir4 Direction;
 
         private IInteractable baseMenu;
-        public MenuCursor(IInteractable baseMenu)
+        public MenuCursor(IInteractable baseMenu) : this("", baseMenu, Dir4.Right) { }
+        public MenuCursor(string label, IInteractable baseMenu) : this(label, baseMenu, Dir4.Right) { }
+        public MenuCursor(IInteractable baseMenu, Dir4 dir) : this("", baseMenu, dir) { }
+        public MenuCursor(string label, IInteractable baseMenu, Dir4 dir)
         {
-            this.baseMenu = baseMenu;
-            this.Direction = Dir4.Right;
-        }
-        public MenuCursor(IInteractable baseMenu, Dir4 dir)
-        {
+            this.Label = label;
             this.baseMenu = baseMenu;
             this.Direction = dir;
         }
@@ -54,8 +53,6 @@ namespace RogueEssence.Menu
                         break;
                 }
             }
-
-
         }
     }
 }

--- a/RogueEssence/Menu/MenuElements/MenuCursor.cs
+++ b/RogueEssence/Menu/MenuElements/MenuCursor.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuCursor : IMenuElement
     {
+        public string Label { get; set; }
         protected const int CURSOR_FLASH_TIME = 24;
 
         public ulong PrevTick;

--- a/RogueEssence/Menu/MenuElements/MenuDigits.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDigits.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuDigits : IMenuElement
     {
+        public string Label { get; set; }
         public const int DIGIT_SPACE = 9;
 
         public int Amount;

--- a/RogueEssence/Menu/MenuElements/MenuDigits.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDigits.cs
@@ -16,11 +16,18 @@ namespace RogueEssence.Menu
         public Loc Loc;
 
         public MenuDigits(int digits, int minDigits, Loc loc)
-            : this(digits, minDigits, loc, Color.White)
+            : this("", digits, minDigits, loc, Color.White)
+        { }
+        public MenuDigits(string label, int digits, int minDigits, Loc loc)
+            : this(label, digits, minDigits, loc, Color.White)
         { }
 
         public MenuDigits(int digits, int minDigits, Loc loc, Color color)
+            : this("", digits, minDigits, loc, color)
+        { }
+        public MenuDigits(string label, int digits, int minDigits, Loc loc, Color color)
         {
+            Label = label;
             Amount = digits;
             MinDigits = minDigits;
             Loc = loc;

--- a/RogueEssence/Menu/MenuElements/MenuDirTex.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDirTex.cs
@@ -17,6 +17,7 @@ namespace RogueEssence.Menu
             BG
         }
 
+        public string Label { get; set; }
         public Loc Loc;
         public TexType Type;
         public AnimData Anim;

--- a/RogueEssence/Menu/MenuElements/MenuDirTex.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDirTex.cs
@@ -22,8 +22,10 @@ namespace RogueEssence.Menu
         public TexType Type;
         public AnimData Anim;
 
-        public MenuDirTex(Loc loc, TexType type, AnimData texture)
+        public MenuDirTex(Loc loc, TexType type, AnimData texture) : this("", loc, type, texture) { }
+        public MenuDirTex(string label, Loc loc, TexType type, AnimData texture)
         {
+            Label = label;
             Loc = loc;
             Type = type;
             Anim = texture;

--- a/RogueEssence/Menu/MenuElements/MenuDivider.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDivider.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuDivider : IMenuElement
     {
+        public string Label { get; set; }
         public int Length { get; set; }
         public Loc Loc { get; set; }
 

--- a/RogueEssence/Menu/MenuElements/MenuDivider.cs
+++ b/RogueEssence/Menu/MenuElements/MenuDivider.cs
@@ -11,7 +11,8 @@ namespace RogueEssence.Menu
         public int Length { get; set; }
         public Loc Loc { get; set; }
 
-        public MenuDivider(Loc loc, int length)
+        public MenuDivider(Loc loc, int length) : this("", loc, length) { }
+        public MenuDivider(string label, Loc loc, int length)
         {
             Length = length;
             Loc = loc;

--- a/RogueEssence/Menu/MenuElements/MenuGraphic.cs
+++ b/RogueEssence/Menu/MenuElements/MenuGraphic.cs
@@ -17,8 +17,10 @@ namespace RogueEssence.Menu
         public GraphicType Type { get; set; }
         public Loc Texture { get; set; }
 
-        public MenuGraphic(Loc loc, GraphicType type, Loc texture)
+        public MenuGraphic(Loc loc, GraphicType type, Loc texture) : this("", loc, type, texture) { }
+        public MenuGraphic(string label, Loc loc, GraphicType type, Loc texture)
         {
+            Label = label;
             Loc = loc;
             Type = type;
             Texture = texture;

--- a/RogueEssence/Menu/MenuElements/MenuGraphic.cs
+++ b/RogueEssence/Menu/MenuElements/MenuGraphic.cs
@@ -12,6 +12,7 @@ namespace RogueEssence.Menu
             Button
         }
 
+        public string Label { get; set; }
         public Loc Loc { get; set; }
         public GraphicType Type { get; set; }
         public Loc Texture { get; set; }

--- a/RogueEssence/Menu/MenuElements/MenuPortrait.cs
+++ b/RogueEssence/Menu/MenuElements/MenuPortrait.cs
@@ -8,6 +8,7 @@ namespace RogueEssence.Menu
 {
     public class MenuPortrait : IMenuElement
     {
+        public string Label { get; set; }
         public Loc Loc;
         public MonsterID Speaker;
         public EmoteStyle SpeakerEmotion;

--- a/RogueEssence/Menu/MenuElements/MenuPortrait.cs
+++ b/RogueEssence/Menu/MenuElements/MenuPortrait.cs
@@ -13,11 +13,18 @@ namespace RogueEssence.Menu
         public MonsterID Speaker;
         public EmoteStyle SpeakerEmotion;
 
-        public MenuPortrait(Loc loc, MonsterID speaker) : this(loc, speaker, new EmoteStyle())
+        public MenuPortrait(Loc loc, MonsterID speaker) : this("", loc, speaker, new EmoteStyle())
         { }
 
-        public MenuPortrait(Loc loc, MonsterID speaker, EmoteStyle emote)
+        public MenuPortrait(string label, Loc loc, MonsterID speaker) : this(label, loc, speaker, new EmoteStyle())
+        { }
+
+        public MenuPortrait(Loc loc, MonsterID speaker, EmoteStyle emote) : this("", loc, speaker, emote)
+        { }
+
+        public MenuPortrait(string label, Loc loc, MonsterID speaker, EmoteStyle emote)
         {
+            Label = label;
             Loc = loc;
             Speaker = speaker;
             SpeakerEmotion = emote;

--- a/RogueEssence/Menu/MenuElements/MenuSetting.cs
+++ b/RogueEssence/Menu/MenuElements/MenuSetting.cs
@@ -29,13 +29,20 @@ namespace RogueEssence.Menu
 
         public MenuSetting() { }
 
-        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, Action choiceAction) : this(text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, defaultChoice, choiceAction) { }
+        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, Action choiceAction) : this("", text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, defaultChoice, choiceAction) { }
 
-        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this(text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+        public MenuSetting(string label, string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, Action choiceAction) : this(label, text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, defaultChoice, choiceAction) { }
 
-        public MenuSetting(string text, Color nrmColor, Color chgColor, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction)
+        public MenuSetting(string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this("", text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+
+        public MenuSetting(string label, string text, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this(label, text, Color.White, Color.Yellow, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+
+        public MenuSetting(string text, Color nrmColor, Color chgColor, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction) : this("", text, nrmColor, chgColor, choiceOffset, choiceWidth, totalChoices, defaultChoice, savedChoice, choiceAction) { }
+
+        public MenuSetting(string label, string text, Color nrmColor, Color chgColor, int choiceOffset, int choiceWidth, List<string> totalChoices, int defaultChoice, int savedChoice, Action choiceAction)
             : this()
         {
+            Label = label;
             Bounds = new Rect();
             ChoiceAction = choiceAction;
             TotalChoices = totalChoices;

--- a/RogueEssence/Menu/MenuElements/MenuSetting.cs
+++ b/RogueEssence/Menu/MenuElements/MenuSetting.cs
@@ -8,6 +8,7 @@ namespace RogueEssence.Menu
 {
     public class MenuSetting : IChoosable
     {
+        public string Label { get; set; }
         public MenuText SettingName;
         public MenuText Setting;
 

--- a/RogueEssence/Menu/MenuElements/MenuStatBar.cs
+++ b/RogueEssence/Menu/MenuElements/MenuStatBar.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
+using System.Reflection.Emit;
 
 namespace RogueEssence.Menu
 {
@@ -13,9 +14,12 @@ namespace RogueEssence.Menu
         public Loc Loc { get; set; }
         public bool Shadow { get; set; }
 
-        public MenuStatBar(Loc loc, int length, Color color) : this(loc, length, color, true) { }
-        public MenuStatBar(Loc loc, int length, Color color, bool shadow)
+        public MenuStatBar(Loc loc, int length, Color color) : this("", loc, length, color, true) { }
+        public MenuStatBar(string label, Loc loc, int length, Color color) : this(label, loc, length, color, true) { }
+        public MenuStatBar(Loc loc, int length, Color color, bool shadow) : this("", loc, length, color, true) { }
+        public MenuStatBar(string label, Loc loc, int length, Color color, bool shadow)
         {
+            Label = label;
             Length = length;
             Loc = loc;
             Color = color;

--- a/RogueEssence/Menu/MenuElements/MenuStatBar.cs
+++ b/RogueEssence/Menu/MenuElements/MenuStatBar.cs
@@ -7,6 +7,7 @@ namespace RogueEssence.Menu
 {
     public class MenuStatBar : IMenuElement
     {
+        public string Label { get; set; }
         public int Length { get; set; }
         public Color Color { get; set; }
         public Loc Loc { get; set; }

--- a/RogueEssence/Menu/MenuElements/MenuText.cs
+++ b/RogueEssence/Menu/MenuElements/MenuText.cs
@@ -19,19 +19,33 @@ namespace RogueEssence.Menu
         private List<(int idx, Color color)> textColor;
 
         public MenuText(string text, Loc loc)
-            : this(text, loc, DirH.Left)
+            : this("", text, loc, DirH.Left)
+        { }
+        public MenuText(string label, string text, Loc loc)
+            : this(label, text, loc, DirH.Left)
         { }
 
         public MenuText(string text, Loc loc, Color color)
-            : this(text, loc, DirV.Up, DirH.Left, color)
+            : this("", text, loc, DirV.Up, DirH.Left, color)
+        { }
+        public MenuText(string label, string text, Loc loc, Color color)
+            : this(label, text, loc, DirV.Up, DirH.Left, color)
         { }
 
         public MenuText(string text, Loc loc, DirH align)
-            : this(text, loc, DirV.Up, align, Color.White)
+            : this("", text, loc, DirV.Up, align, Color.White)
+        { }
+
+        public MenuText(string label, string text, Loc loc, DirH align)
+            : this(label, text, loc, DirV.Up, align, Color.White)
         { }
 
         public MenuText(string text, Loc loc, DirV alignV, DirH alignH, Color color)
+            : this("", text, loc, alignV, alignH, color)
+        { }
+        public MenuText(string label, string text, Loc loc, DirV alignV, DirH alignH, Color color)
         {
+            Label = label;
             Loc = loc;
             AlignV = alignV;
             AlignH = alignH;

--- a/RogueEssence/Menu/MenuElements/MenuText.cs
+++ b/RogueEssence/Menu/MenuElements/MenuText.cs
@@ -10,6 +10,7 @@ namespace RogueEssence.Menu
 {
     public class MenuText : IMenuElement
     {
+        public string Label { get; set; }
         public string Text { get; private set; }
         public Color Color;
         public DirV AlignV;

--- a/RogueEssence/Menu/MenuManager.cs
+++ b/RogueEssence/Menu/MenuManager.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Dungeon;
 using System.Text.RegularExpressions;
 using RogueElements;
+using RogueEssence.Script;
 
 namespace RogueEssence.Menu
 {
@@ -37,6 +38,7 @@ namespace RogueEssence.Menu
             if (menuModeDepth == 0)
                 throw new Exception("Can't add menu while not in menu mode");
 
+            LuaEngine.Instance.OnAddMenu(menu);
             if (menus.Count > 0)
                 menus[menus.Count - 1].Inactive = true;
             menu.Inactive = false;
@@ -49,6 +51,7 @@ namespace RogueEssence.Menu
             if (menuModeDepth == 0)
                 throw new Exception("Can't replace menu while not in menu mode");
 
+            LuaEngine.Instance.OnAddMenu(menu);
             menu.BlockPrevious = menus[menus.Count - 1].BlockPrevious;
             menus.RemoveAt(menus.Count - 1);
             menus.Add(menu);
@@ -79,6 +82,7 @@ namespace RogueEssence.Menu
 
         public IEnumerator<YieldInstruction> ProcessMenuCoroutine(IInteractable menu)
         {
+            LuaEngine.Instance.OnAddMenu(menu);
             if (menus.Count > 0)
                 menus[menus.Count - 1].Inactive = true;
             menu.Inactive = false;

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using RogueElements;
 using RogueEssence.Content;
 
@@ -151,6 +152,45 @@ namespace RogueEssence.Menu
         public void ImportTotalChoices(IChoosable[] choices)
         {
             TotalChoices = SortIntoPages(choices, SpacesPerPage);
+        }
+
+        public override int GetChoiceIndexByLabel(string label)
+        {
+            return GetChoiceIndexesByLabel(label)[label];
+        }
+        public override Dictionary<string, int> GetChoiceIndexesByLabel(params string[] labels)
+        {
+            Dictionary<string, int> poss = new();
+            List<string> labelList = labels.ToList();
+            foreach (string label in labels)
+                poss.Add(label, -1);
+
+            for (int ii = 0; ii < TotalChoices.Length; ii++)
+            {
+                bool found = false;
+                IChoosable[] page = TotalChoices[ii];
+                for (int jj = 0; jj < TotalChoices.Length; jj++)
+                {
+                    IChoosable choice = page[jj];
+                    if (choice.HasLabel())
+                    {
+                        for (int kk = 0; kk < labelList.Count; kk++)
+                        {
+                            string label = labelList[kk];
+                            if(choice.Label == label)
+                            {
+                                found = true;
+                                poss[label] = ii * SpacesPerPage + jj;
+                                labelList.RemoveAt(kk);
+                                break;
+                            }
+                        }
+                    }
+                    if (found) break;
+                }
+                if (found && labelList.Count == 0) break;
+            }
+            return poss;
         }
     }
 }

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -152,6 +152,7 @@ namespace RogueEssence.Menu
         public void ImportTotalChoices(IChoosable[] choices)
         {
             TotalChoices = SortIntoPages(choices, SpacesPerPage);
+            SetPage(CurrentPage);
         }
 
         public override int GetChoiceIndexByLabel(string label)

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -169,7 +169,7 @@ namespace RogueEssence.Menu
             {
                 bool found = false;
                 IChoosable[] page = TotalChoices[ii];
-                for (int jj = 0; jj < TotalChoices.Length; jj++)
+                for (int jj = 0; jj < TotalChoices[ii].Length; jj++)
                 {
                     IChoosable choice = page[jj];
                     if (choice.HasLabel())

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -135,5 +135,22 @@ namespace RogueEssence.Menu
             int index = totalIndex % SpacesPerPage;
             return TotalChoices[page][index];
         }
+
+        public List<IChoosable> ExportTotalChoices()
+        {
+            List<IChoosable> allChoices = new();
+            foreach (IChoosable[] page in TotalChoices)
+                foreach (IChoosable choice in page)
+                    allChoices.Add(choice);
+            return allChoices;
+        }
+        public void ImportTotalChoices(List<IChoosable> choices)
+        {
+            ImportTotalChoices(choices.ToArray());
+        }
+        public void ImportTotalChoices(IChoosable[] choices)
+        {
+            TotalChoices = SortIntoPages(choices, SpacesPerPage);
+        }
     }
 }

--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -6,8 +6,10 @@ namespace RogueEssence.Menu
     public class OthersMenu : TitledStripMenu
     {
         public List<MenuTextChoice> Choices { get; set; }
-        public OthersMenu()
+        public OthersMenu() : this(MenuLabel.OTHERS.ToString()) { }
+        public OthersMenu(string label)
         {
+            Label = label;
             Choices = new List<MenuTextChoice>();
         }
 

--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -24,10 +24,10 @@ namespace RogueEssence.Menu
         public void SetupChoices()
         {
             Choices.Clear();
-            Choices.Add(new MenuTextChoice("MSG_LOG", Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
-            Choices.Add(new MenuTextChoice("SETTINGS", Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
-            Choices.Add(new MenuTextChoice("KEYBOARD", Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
-            Choices.Add(new MenuTextChoice("GAMEPAD", Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.MSG_LOG.ToString(), Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.SETTINGS.ToString(), Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.KEYBOARD.ToString(), Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.GAMEPAD.ToString(), Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
         }
 
         public void InitMenu()

--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -22,10 +22,10 @@ namespace RogueEssence.Menu
         public void SetupChoices()
         {
             Choices.Clear();
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
-            Choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice("MSG_LOG", Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
+            Choices.Add(new MenuTextChoice("SETTINGS", Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
+            Choices.Add(new MenuTextChoice("KEYBOARD", Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
+            Choices.Add(new MenuTextChoice("GAMEPAD", Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
         }
 
         public void InitMenu()

--- a/RogueEssence/Menu/ScriptableMenu.cs
+++ b/RogueEssence/Menu/ScriptableMenu.cs
@@ -18,6 +18,8 @@ namespace RogueEssence.Menu
 
         protected Action<InputManager> UpdateFunction;
 
+        public ScriptableMenu(string label, int x, int y, int w, int h, Action<InputManager> updateFunction) : this(x, y, w, h, updateFunction)
+        { Label = label; }
         public ScriptableMenu(int x, int y, int w, int h, Action<InputManager> updateFunction)
         {
             UpdateFunction = updateFunction;
@@ -64,6 +66,9 @@ namespace RogueEssence.Menu
 
         public Action<LuaTable> MultiSelectFunction;
 
+        public ScriptableSingleStripMenu(string label, int x, int y, int minWidth, LuaTable choicesPairs, object defaultChoice, Action cancelFun) : this(label, x, y, minWidth, choicesPairs, defaultChoice, cancelFun, -1, null) { }
+        public ScriptableSingleStripMenu(string label, int x, int y, int minWidth, LuaTable choicesPairs, object defaultChoice, Action cancelFun, int multiSelect, Action<LuaTable> onMultiSelect) : this(label, x, y, minWidth, choicesPairs, defaultChoice, cancelFun, new IntRange(-1, multiSelect + 1), onMultiSelect) { }
+        public ScriptableSingleStripMenu(string label, int x, int y, int minWidth, LuaTable choicesPairs, object defaultChoice, Action cancelFun, IntRange multiSelect, Action<LuaTable> onMultiSelect) : this(x, y, minWidth, choicesPairs, defaultChoice, cancelFun, multiSelect, onMultiSelect) { Label = label; }
         public ScriptableSingleStripMenu(int x, int y, int minWidth, LuaTable choicesPairs, object defaultChoice, Action cancelFun) : this(x, y, minWidth, choicesPairs, defaultChoice, cancelFun, -1, null) { }
         public ScriptableSingleStripMenu(int x, int y, int minWidth, LuaTable choicesPairs, object defaultChoice, Action cancelFun, int multiSelect, Action<LuaTable> onMultiSelect) : this(x, y, minWidth, choicesPairs, defaultChoice, cancelFun, new IntRange(-1, multiSelect+1), onMultiSelect) { }
         public ScriptableSingleStripMenu(int x, int y, int minWidth, LuaTable choicesPairs, object defaultChoice, Action cancelFun, IntRange multiSelect, Action<LuaTable> onMultiSelect)
@@ -198,10 +203,13 @@ namespace RogueEssence.Menu
         public override bool CanMenu => MenuFunction is not null;
         public override bool CanCancel => CancelFunction is not null;
 
+        public ScriptableMultiPageMenu(string label, Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu) : this(label, start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu, true) { }
+        public ScriptableMultiPageMenu(string label, Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu, bool showPagesOnSingle) : this(label, start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu, showPagesOnSingle, -1, null) { }
+        public ScriptableMultiPageMenu(string label, Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu, bool showPagesOnSingle, int multiSelect, Action<LuaTable> onMultiSelect) : this(label, start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu, showPagesOnSingle, new IntRange(-1, multiSelect + 1), onMultiSelect) { }
+        public ScriptableMultiPageMenu(string label, Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu, bool showPagesOnSingle, IntRange multiSelect, Action<LuaTable> onMultiSelect) : this(start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu,showPagesOnSingle, multiSelect, onMultiSelect) { Label = label; }
         public ScriptableMultiPageMenu(Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu) : this(start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu, true) { }
         public ScriptableMultiPageMenu(Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu, bool showPagesOnSingle) : this(start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu, showPagesOnSingle, -1, null) { }
         public ScriptableMultiPageMenu(Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu, bool showPagesOnSingle, int multiSelect, Action<LuaTable> onMultiSelect) : this(start, width, title, totalChoices, defaultTotalChoice, spacesPerPage, onCancel, onMenu, showPagesOnSingle, new IntRange(-1, multiSelect + 1), onMultiSelect) { }
-
         public ScriptableMultiPageMenu(Loc start, int width, string title, IChoosable[] totalChoices, int defaultTotalChoice, int spacesPerPage, Action onCancel, Action onMenu, bool showPagesOnSingle, IntRange multiSelect, Action<LuaTable> onMultiSelect)
         {
             this.CancelFunction = onCancel;

--- a/RogueEssence/Menu/Settings/SettingsMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsMenu.cs
@@ -13,9 +13,11 @@ namespace RogueEssence.Menu
     {
         //needs a summary menu?
         bool inGame;
-        
-        public SettingsMenu()
+
+        public SettingsMenu() : this(MenuLabel.SETTINGS.ToString()) { }
+        public SettingsMenu(string label)
         {
+            Label = label;
             this.inGame = false;
             if (GameManager.Instance.CurrentScene == GroundScene.Instance)
                 this.inGame = true;

--- a/RogueEssence/Menu/Skills/SkillChosenMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillChosenMenu.cs
@@ -10,13 +10,15 @@ namespace RogueEssence.Menu
 {
     public class SkillChosenMenu : SingleStripMenu
     {
+        private string parentLabel;
 
         private int teamIndex;
         private int skillSlot;
 
 
-        public SkillChosenMenu(int teamIndex, int skillSlot)
+        public SkillChosenMenu(string parentLabel, int teamIndex, int skillSlot)
         {
+            this.parentLabel = parentLabel;
             this.teamIndex = teamIndex;
             this.skillSlot = skillSlot;
 
@@ -49,7 +51,7 @@ namespace RogueEssence.Menu
         {
             MenuManager.Instance.RemoveMenu();
 
-            MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.SetSkill, Dir8.None, teamIndex, skillSlot), teamIndex, skillSlot);
+            MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.SetSkill, Dir8.None, teamIndex, skillSlot), parentLabel, teamIndex, skillSlot);
         }
 
         private void shiftPosition(bool switchDown)
@@ -63,7 +65,7 @@ namespace RogueEssence.Menu
                 swapSlot++;
                 newSlot += 2;
             }
-            MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, teamIndex, swapSlot), teamIndex, newSlot);
+            MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, teamIndex, swapSlot), parentLabel, teamIndex, newSlot);
         }
     }
 }

--- a/RogueEssence/Menu/Skills/SkillMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillMenu.cs
@@ -17,8 +17,12 @@ namespace RogueEssence.Menu
         SkillSummary summaryMenu;
 
         public SkillMenu(int teamIndex) : this(teamIndex, -1) { }
-        public SkillMenu(int teamIndex, int skillSlot)
-        {
+        public SkillMenu(int teamIndex, int skillSlot) : this("SKILL", teamIndex, skillSlot) { }
+        public SkillMenu(string label, int teamIndex) : this(label, teamIndex, -1) { }
+        public SkillMenu(string label, int teamIndex, int skillSlot)
+        { 
+            Label = label;
+
             List<Character> openPlayers = new List<Character>();
             foreach (Character character in DataManager.Instance.Save.ActiveTeam.Players)
                 openPlayers.Add(character);
@@ -81,14 +85,14 @@ namespace RogueEssence.Menu
             else if (input.JustPressed(FrameInput.InputType.SortItems))
             {
                 GameManager.Instance.SE("Menu/Toggle");
-                MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.SetSkill, Dir8.None, CurrentPage, CurrentChoice), CurrentPage, CurrentChoice);
+                MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.SetSkill, Dir8.None, CurrentPage, CurrentChoice), Label, CurrentPage, CurrentChoice);
             }
             else if (input[FrameInput.InputType.SelectItems] && input.Direction == Dir8.Up && input.PrevDirection != Dir8.Up)
             {
                 if (CurrentChoice > 0)
                 {
                     GameManager.Instance.SE("Menu/Toggle");
-                    MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, CurrentPage, CurrentChoice - 1), CurrentPage, CurrentChoice - 1);
+                    MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, CurrentPage, CurrentChoice - 1), Label, CurrentPage, CurrentChoice - 1);
                 }
                 else
                     GameManager.Instance.SE("Menu/Cancel");
@@ -98,7 +102,7 @@ namespace RogueEssence.Menu
                 if (CurrentChoice < Choices.Count - 1)
                 {
                     GameManager.Instance.SE("Menu/Toggle");
-                    MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, CurrentPage, CurrentChoice), CurrentPage, CurrentChoice + 1);
+                    MenuManager.Instance.NextAction = SkillMenu.MoveCommand(new GameAction(GameAction.ActionType.ShiftSkill, Dir8.None, CurrentPage, CurrentChoice), Label, CurrentPage, CurrentChoice + 1);
                 }
                 else
                     GameManager.Instance.SE("Menu/Cancel");
@@ -161,10 +165,10 @@ namespace RogueEssence.Menu
         }
 
 
-        public static IEnumerator<YieldInstruction> MoveCommand(GameAction action, int teamSlot, int switchSlot)
+        public static IEnumerator<YieldInstruction> MoveCommand(GameAction action, string label, int teamSlot, int switchSlot)
         {
             yield return CoroutineManager.Instance.StartCoroutine((GameManager.Instance.CurrentScene == DungeonScene.Instance) ? DungeonScene.Instance.ProcessPlayerInput(action) : GroundScene.Instance.ProcessInput(action));
-            MenuManager.Instance.ReplaceMenu(new SkillMenu(teamSlot, switchSlot));
+            MenuManager.Instance.ReplaceMenu(new SkillMenu(label, teamSlot, switchSlot));
         }
 
     }

--- a/RogueEssence/Menu/Skills/SkillMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillMenu.cs
@@ -114,7 +114,7 @@ namespace RogueEssence.Menu
         private void choose(int choice)
         {
             if (DataManager.Instance.CurrentReplay == null)
-                MenuManager.Instance.AddMenu(new SkillChosenMenu(CurrentPage, choice), true);
+                MenuManager.Instance.AddMenu(new SkillChosenMenu(Label, CurrentPage, choice), true);
         }
 
         private int getMenuWidth(int min, int max, int chkWidth, int chargesWidth, int skillIndent, string title, List<Character> openPlayers)

--- a/RogueEssence/Menu/Skills/SkillMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillMenu.cs
@@ -17,7 +17,7 @@ namespace RogueEssence.Menu
         SkillSummary summaryMenu;
 
         public SkillMenu(int teamIndex) : this(teamIndex, -1) { }
-        public SkillMenu(int teamIndex, int skillSlot) : this("SKILL", teamIndex, skillSlot) { }
+        public SkillMenu(int teamIndex, int skillSlot) : this(MenuLabel.SKILLS.ToString(), teamIndex, skillSlot) { }
         public SkillMenu(string label, int teamIndex) : this(label, teamIndex, -1) { }
         public SkillMenu(string label, int teamIndex, int skillSlot)
         { 

--- a/RogueEssence/Menu/Team/TacticsMenu.cs
+++ b/RogueEssence/Menu/Team/TacticsMenu.cs
@@ -12,8 +12,11 @@ namespace RogueEssence.Menu
         //needs a summary menu
         private int releasedTactics;
 
-        public TacticsMenu()
+        public TacticsMenu() : this(MenuLabel.TACTICS.ToString()) { }
+        public TacticsMenu(string label)
         {
+            Label = label;
+
             //individual tactics
             MenuSetting[] totalChoices = new MenuSetting[DataManager.Instance.Save.ActiveTeam.Players.Count + 1];
             

--- a/RogueEssence/Menu/Team/TeamChosenMenu.cs
+++ b/RogueEssence/Menu/Team/TeamChosenMenu.cs
@@ -183,7 +183,7 @@ namespace RogueEssence.Menu
         public IEnumerator<YieldInstruction> MoveCommand(GameAction action, int switchSlot)
         {
             yield return CoroutineManager.Instance.StartCoroutine((GameManager.Instance.CurrentScene == DungeonScene.Instance) ? DungeonScene.Instance.ProcessPlayerInput(action) : GroundScene.Instance.ProcessInput(action));
-            MenuManager.Instance.ReplaceMenu(new TeamMenu(false, switchSlot));
+            MenuManager.Instance.ReplaceMenu(new TeamMenu(MenuLabel.TEAM_SWITCH.ToString(), false, switchSlot));
         }
     }
 }

--- a/RogueEssence/Menu/Team/TeamMenu.cs
+++ b/RogueEssence/Menu/Team/TeamMenu.cs
@@ -20,8 +20,14 @@ namespace RogueEssence.Menu
 
         public TeamMenu(bool sendHome) : this(sendHome, -1)
         { }
-        public TeamMenu(bool sendHome, int teamSlot)
+        public TeamMenu(bool sendHome, int teamSlot) : this(MenuLabel.TEAM.ToString(), sendHome, teamSlot)
+        { }
+        public TeamMenu(string label, bool sendHome) : this(label, sendHome, -1)
+        { }
+        public TeamMenu(string label, bool sendHome, int teamSlot)
         {
+            Label = label;
+
             int menuWidth = 160;
             this.sendHome = sendHome;
             bool overrideSendHome = false;

--- a/RogueEssence/Menu/Underfoot/ItemUnderfootMenu.cs
+++ b/RogueEssence/Menu/Underfoot/ItemUnderfootMenu.cs
@@ -116,7 +116,7 @@ namespace RogueEssence.Menu
 
         private void ReplaceAction()
         {
-            MenuManager.Instance.AddMenu(new ItemMenu(-1), false);
+            MenuManager.Instance.AddMenu(new ItemMenu(MenuLabel.INVENTORY_REPLACE.ToString(), -1), false);
         }
         private void UseSelfAction()
         {

--- a/RogueEssence/Menu/Underfoot/ItemUnderfootMenu.cs
+++ b/RogueEssence/Menu/Underfoot/ItemUnderfootMenu.cs
@@ -13,8 +13,10 @@ namespace RogueEssence.Menu
     {
         ItemSummary summaryMenu;
 
-        public ItemUnderfootMenu(int mapItemSlot)
+        public ItemUnderfootMenu(int mapItemSlot) : this(MenuLabel.GROUND_ITEM.ToString(), mapItemSlot) { }
+        public ItemUnderfootMenu(string label, int mapItemSlot)
         {
+            Label = label;
             MapItem mapItem = ZoneManager.Instance.CurrentMap.Items[mapItemSlot];
             string itemName = mapItem.GetDungeonName();
 

--- a/RogueEssence/Menu/Underfoot/TileUnderfootMenu.cs
+++ b/RogueEssence/Menu/Underfoot/TileUnderfootMenu.cs
@@ -11,8 +11,10 @@ namespace RogueEssence.Menu
     {
         TileSummary summaryMenu;
 
-        public TileUnderfootMenu(string tileIndex)
+        public TileUnderfootMenu(string tileIndex) : this(MenuLabel.GROUND_TILE.ToString(), tileIndex) { }
+        public TileUnderfootMenu(string label, string tileIndex)
         {
+            Label = label;
             Data.TileData entry = Data.DataManager.Instance.GetTile(tileIndex);
             List<MenuTextChoice> choices = new List<MenuTextChoice>();
             


### PR DESCRIPTION
- new OnAddMenu event
- MenuLabel enum that can be used to set labels that are consistent between both menus and options
- Labels for many common menus like main, others, skills and settings
- LabelContains method in ILabeled
- Scriptable menus can be labeled upon creation