### PR TITLE
Import/ExportChoices calls for ChoiceMenu 

### DIFF
--- a/RogueEssence/Lua/LuaEngine.cs
+++ b/RogueEssence/Lua/LuaEngine.cs
@@ -1934,7 +1934,10 @@ namespace RogueEssence.Script
         {
             DiagManager.Instance.LogInfo("LuaEngine.OnAddMenu()...");
             if (menu is InteractableMenu interactable && ((ILabeled)interactable).HasLabel())
-                DiagManager.Instance.LogInfo("Menu Label: " + interactable.Label);
+            {
+                string type = interactable is MultiPageMenu ? "MultiPageMenu" : interactable is ChoiceMenu ? "ChoiceMenu" : "InteractableMenu";
+                DiagManager.Instance.LogInfo($"Menu Type: {type}. Label: {interactable.Label}");
+            }
             m_scrsvc.Publish(EServiceEvents.AddMenu.ToString(), menu);
         }
 

--- a/RogueEssence/Lua/LuaEngine.cs
+++ b/RogueEssence/Lua/LuaEngine.cs
@@ -1932,9 +1932,9 @@ namespace RogueEssence.Script
         /// </summary>
         public void OnAddMenu(IInteractable menu)
         {
-            DiagManager.Instance.LogInfo("LuaEngine.OnAddMenu()...");
             if (menu is InteractableMenu interactable && ((ILabeled)interactable).HasLabel())
             {
+                DiagManager.Instance.LogInfo("Opening labeled menu...");
                 string type = interactable is MultiPageMenu ? "MultiPageMenu" : interactable is ChoiceMenu ? "ChoiceMenu" : "InteractableMenu";
                 DiagManager.Instance.LogInfo($"Menu Type: {type}. Label: {interactable.Label}");
             }

--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using RogueElements;
-using System.Linq;
 
 namespace RogueEssence.Menu
 {

--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -24,7 +24,7 @@ namespace RogueEssence.Menu
                 yield return nonChoice;
         }
 
-        public virtual List<IChoosable> ExportChoices() => Choices;
+        public virtual List<IChoosable> ExportChoices() => new(Choices);
         public void ImportChoices(List<IChoosable> choices)
         {
             ImportChoices(choices.ToArray());
@@ -37,7 +37,7 @@ namespace RogueEssence.Menu
         }
         public virtual Dictionary<string, int> GetChoiceIndicesByLabel(params string[] labels)
         {
-            return SearchLabels(labels, ExportChoices());
+            return SearchLabels(labels, Choices);
         }
 
         public int GetNonChoiceIndexByLabel(string label)

--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -25,10 +25,6 @@ namespace RogueEssence.Menu
                 yield return nonChoice;
         }
 
-        public override Dictionary<string, int> GetElementIndicesByLabel(params string[] labels)
-        {
-            return SearchLabels(labels, Elements);
-        }
 
         public int GetChoiceIndexByLabel(string label)
         {

--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -25,6 +25,12 @@ namespace RogueEssence.Menu
                 yield return nonChoice;
         }
 
+        public virtual List<IChoosable> ExportChoices() => Choices;
+        public void ImportChoices(List<IChoosable> choices)
+        {
+            ImportChoices(choices.ToArray());
+        }
+        public abstract void ImportChoices(params IChoosable[] choices);
 
         public int GetChoiceIndexByLabel(string label)
         {
@@ -32,7 +38,7 @@ namespace RogueEssence.Menu
         }
         public virtual Dictionary<string, int> GetChoiceIndicesByLabel(params string[] labels)
         {
-            return SearchLabels(labels, Choices);
+            return SearchLabels(labels, ExportChoices());
         }
 
         public int GetNonChoiceIndexByLabel(string label)

--- a/RogueEssence/Menu/Dungeons/DungeonsMenu.cs
+++ b/RogueEssence/Menu/Dungeons/DungeonsMenu.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using RogueElements;
 using RogueEssence.Data;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework;
 using RogueEssence.Content;
 using RogueEssence.Dungeon;
 

--- a/RogueEssence/Menu/MenuBase.cs
+++ b/RogueEssence/Menu/MenuBase.cs
@@ -3,7 +3,6 @@ using RogueElements;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RogueEssence.Content;
-using System.Linq;
 
 namespace RogueEssence.Menu
 {

--- a/RogueEssence/Menu/MultiPageMenu.cs
+++ b/RogueEssence/Menu/MultiPageMenu.cs
@@ -136,7 +136,7 @@ namespace RogueEssence.Menu
             return TotalChoices[page][index];
         }
 
-        public List<IChoosable> ExportTotalChoices()
+        public override List<IChoosable> ExportChoices()
         {
             List<IChoosable> allChoices = new List<IChoosable>();
             foreach (IChoosable[] page in TotalChoices)
@@ -144,11 +144,7 @@ namespace RogueEssence.Menu
                     allChoices.Add(choice);
             return allChoices;
         }
-        public void ImportTotalChoices(List<IChoosable> choices)
-        {
-            ImportTotalChoices(choices.ToArray());
-        }
-        public void ImportTotalChoices(params IChoosable[] choices)
+        public override void ImportChoices(params IChoosable[] choices)
         {
             TotalChoices = SortIntoPages(choices, SpacesPerPage);
             SetPage(CurrentPage);
@@ -156,7 +152,7 @@ namespace RogueEssence.Menu
 
         public override Dictionary<string, int> GetChoiceIndicesByLabel(params string[] labels)
         {
-            return SearchLabels(labels, ExportTotalChoices());
+            return SearchLabels(labels, ExportChoices());
         }
     }
 }

--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -34,6 +34,5 @@ namespace RogueEssence.Menu
         {
             Initialize(new Loc(16, 16), CalculateChoiceLength(Choices, 72), Text.FormatKey("MENU_OTHERS_TITLE"), Choices.ToArray(), 0);
         }
-
     }
 }

--- a/RogueEssence/Menu/SingleStripMenu.cs
+++ b/RogueEssence/Menu/SingleStripMenu.cs
@@ -218,6 +218,10 @@ namespace RogueEssence.Menu
         protected abstract void MenuPressed();
         protected abstract void Canceled();
         protected abstract void ChoseMultiIndex(List<int> slots);
+        public override void ImportChoices(params IChoosable[] choices)
+        {
+            Initialize(Bounds.Start, CalculateChoiceLength(choices, 72), choices, Math.Min(CurrentChoice, choices.Length));
+        }
     }
 
     public abstract class SingleStripMenu : VertChoiceMenu


### PR DESCRIPTION
- These changes aim to create menu editing "best practices" by standardizing the process of editing choice lists: modders can export the list, edit it, and then import it back in, and the c# code does all the heavylifting from there
- Includes a menu type print alongside label prints
