### PR TITLE
Settings menu rework

### DIFF
--- a/RogueEssence/Menu/Others/OthersMenu.cs
+++ b/RogueEssence/Menu/Others/OthersMenu.cs
@@ -25,7 +25,7 @@ namespace RogueEssence.Menu
         {
             Choices.Clear();
             Choices.Add(new MenuTextChoice(MenuLabel.OTH_MSG_LOG, Text.FormatKey("MENU_MSG_LOG_TITLE"), () => { MenuManager.Instance.AddMenu(new MsgLogMenu(), false); }));
-            Choices.Add(new MenuTextChoice(MenuLabel.OTH_SETTINGS, Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
+            Choices.Add(new MenuTextChoice(MenuLabel.OTH_SETTINGS, Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsTitleMenu(), false); }));
             Choices.Add(new MenuTextChoice(MenuLabel.OTH_KEYBOARD, Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
             Choices.Add(new MenuTextChoice(MenuLabel.OTH_GAMEPAD, Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
         }

--- a/RogueEssence/Menu/Settings/OptionsMenu.cs
+++ b/RogueEssence/Menu/Settings/OptionsMenu.cs
@@ -9,7 +9,7 @@ namespace RogueEssence.Menu
         public OptionsMenu()
         {
             List<MenuTextChoice> choices = new List<MenuTextChoice>();
-            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsMenu(), false); }));
+            choices.Add(new MenuTextChoice(Text.FormatKey("MENU_SETTINGS_TITLE"), () => { MenuManager.Instance.AddMenu(new SettingsTitleMenu(), false); }));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_KEYBOARD_TITLE"), () => { MenuManager.Instance.AddMenu(new KeyControlsMenu(), false); }));
             choices.Add(new MenuTextChoice(Text.FormatKey("MENU_GAMEPAD_TITLE"), () => { MenuManager.Instance.AddMenu(new GamepadControlsMenu(), false); }));
 

--- a/RogueEssence/Menu/Settings/SettingsMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsMenu.cs
@@ -9,6 +9,7 @@ using RogueEssence.Ground;
 
 namespace RogueEssence.Menu
 {
+    //This menu is unused since 0.8.4
     public class SettingsMenu : BaseSettingsMenu
     {
         //needs a summary menu?

--- a/RogueEssence/Menu/Settings/SettingsPageMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsPageMenu.cs
@@ -1,0 +1,141 @@
+﻿using RogueElements;
+using RogueEssence.Content;
+using System.Collections.Generic;
+
+namespace RogueEssence.Menu
+{
+    public class SettingsPageMenu : SingleStripMenu
+    {
+        public SettingsTitleMenu Parent;
+        public SettingsPage Page;
+        public Dictionary<MenuSetting, SettingData> SettingsData = new Dictionary<MenuSetting, SettingData>();
+        public SettingsPageMenu(SettingsTitleMenu parent, SettingsPage page)
+        {
+            Page = page;
+            Parent = parent;
+            Bounds = new Rect(new Loc(16, parent.Bounds.Bottom), new Loc(parent.Bounds.Width, page.Choices.Count * VERT_SPACE + GraphicsManager.MenuBG.TileHeight * 2));
+
+            SetChoices(GenerateChoices(Page).ToArray());
+            CurrentChoice = 0;
+        }
+
+        private List<MenuSetting> GenerateChoices(SettingsPage page)
+        {
+            List<MenuSetting> choices = new List<MenuSetting>();
+            foreach(SettingData setting in page.Choices)
+            {
+                MenuSetting element = new MenuSetting(setting.Name, 88, 72, setting.Options, setting.Default, ConfirmAction);
+                choices.Add(element);
+                SettingsData.Add(element, setting);
+            }
+            return choices;
+        }
+        private void ConfirmAction()
+        {
+            foreach (IChoosable element in Choices)
+            {
+                if(element is MenuSetting || SettingsData.ContainsKey((MenuSetting)element))
+                {
+                    MenuSetting setting = element as MenuSetting;
+                    SettingsData[setting].SaveAction.Invoke(setting);
+                    SettingsData[setting].Default = setting.CurrentChoice;
+                    setting.SaveChoice();
+                }
+            }
+            Page.GlobalSaveAction?.Invoke();
+        }
+
+        protected override void UpdateKeys(InputManager input)
+        {
+            bool moved = false;
+            if (CurrentChoice < Choices.Count && Choices[CurrentChoice] is MenuSetting)
+            {
+                if (IsInputting(input, Dir8.Left))
+                {
+                    MenuSetting setting = (MenuSetting)Choices[CurrentChoice];
+                    SetCurrentSetting(CurrentChoice, (setting.CurrentChoice + setting.TotalChoices.Count - 1) % setting.TotalChoices.Count);
+                    moved = true;
+                }
+                else if (IsInputting(input, Dir8.Right))
+                {
+                    MenuSetting setting = (MenuSetting)Choices[CurrentChoice];
+                    SetCurrentSetting(CurrentChoice, (setting.CurrentChoice + 1) % setting.TotalChoices.Count);
+                    moved = true;
+                }
+            }
+            if (moved)
+            {
+                GameManager.Instance.SE("Menu/Skip");
+                cursor.ResetTimeOffset();
+            }
+            else
+                base.UpdateKeys(input);
+        }
+        protected void SetCurrentSetting(int index, int choice)
+        {
+            MenuSetting setting = Choices[index] as MenuSetting;
+            setting.SetChoice(choice);
+            SettingsData[setting].SettingChangeAction?.Invoke(setting);
+        }
+
+        protected override void MenuPressed()
+        {
+            base.MenuPressed();
+            resetExamples();
+        }
+
+        protected override void Canceled()
+        {
+            base.Canceled();
+            Parent.Preview.Reload();
+            resetExamples();
+        }
+
+        private void resetExamples()
+        {
+            for (int i = 0; i < Choices.Count; i++) {
+                if (Choices[i] is MenuSetting)
+                {
+                    SettingData data = SettingsData[Choices[i] as MenuSetting];
+                    if (data.SettingChangeAction != null)
+                    {
+                        SetCurrentSetting(i, data.Default);
+                        ConfirmAction();
+                    }
+                }
+            }
+        }
+    }
+    public class SettingsPageSummaryMenu : SummaryMenu
+    {
+        public SettingsPage Page;
+        public Dictionary<MenuSetting, SettingData> SettingsData = new Dictionary<MenuSetting, SettingData>();
+        public SettingsPageSummaryMenu(SettingsTitleMenu parent, SettingsPage page) : base(new Rect(new Loc(parent.Bounds.Left, parent.Bounds.Bottom), new Loc(parent.Bounds.Width, 16)))
+        {
+            Page = page;
+            LoadOptions(Page);
+        }
+
+        public void LoadOptions(SettingsPage page)
+        {
+            Page = page;
+            Elements.Clear();
+            List<MenuSetting> choices = new List<MenuSetting>();
+            for (int i = 0; i < page.Choices.Count; i++)
+            {
+                SettingData setting = page.Choices[i];
+                MenuSetting element = new MenuSetting(setting.Name, 88, 72, setting.Options, setting.Default, () => {});
+                element.Bounds = new Rect(new Loc(GraphicsManager.MenuBG.TileWidth + 16 - 5, GraphicsManager.MenuBG.TileHeight + VERT_SPACE * i - 1),
+                    new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2 - 16 + 5 - 4, VERT_SPACE - 2));
+                Elements.Add(element);
+            }
+
+            Bounds = new Rect(Bounds.Start, new Loc(Bounds.Width, page.Choices.Count * VERT_SPACE + GraphicsManager.MenuBG.TileHeight * 2));
+        }
+
+        internal void Reload()
+        {
+            LoadOptions(Page);
+        }
+    }
+}

--- a/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
@@ -1,0 +1,257 @@
+﻿using RogueElements;
+using RogueEssence.Content;
+using RogueEssence.Data;
+using RogueEssence.Dungeon;
+using RogueEssence.Ground;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+
+namespace RogueEssence.Menu
+{
+    public class SettingData
+    {
+        public string Name;
+        public List<string> Options;
+        public int Default;
+        public Action<MenuSetting> SettingChangeAction;
+        public Action<MenuSetting> SaveAction;
+        public SettingData(string name, string[] options, int defaultValue, Action<MenuSetting> saveAction, Action<MenuSetting> settingChangeAction = null) : this(name, options.ToList(), defaultValue, saveAction, settingChangeAction) { }
+        public SettingData(string name, List<string> options, int defaultValue, Action<MenuSetting> saveAction, Action<MenuSetting> settingChangeAction = null)
+        {
+            Name = name;
+            Options = options;
+            Default = defaultValue;
+            SaveAction = saveAction;
+            SettingChangeAction = settingChangeAction;
+        }
+    }
+    public class SettingsPage
+    {
+        public string Title = "";
+        public List<SettingData> Choices = new();
+        public Action GlobalSaveAction;
+        public SettingsPage(string title)
+        {
+            Title = title;
+        }
+        public void AddSetting(string name, string[] options, int defaultValue, Action<MenuSetting> action, Action<MenuSetting> settingChangedAction = null)
+        {
+            AddSetting(name, options.ToList(), defaultValue, action, settingChangedAction);
+        }
+        public void AddSetting(string name, List<string> options, int defaultValue, Action<MenuSetting> action, Action<MenuSetting> settingChangedAction = null)
+        {
+            Choices.Add(new SettingData(name, options, defaultValue, action, settingChangedAction));
+        }
+    }
+
+    public class SettingsTitleMenu : InteractableMenu
+    {
+        private static string _originId = "origin";
+        private readonly List<string> PageIds = new();
+        private readonly Dictionary<string, SettingsPage> Pages = new();
+        private bool checkedPages = false;
+        public static bool InGame
+        {
+            get
+            {
+                if (GameManager.Instance.CurrentScene == GroundScene.Instance ||
+                    GameManager.Instance.CurrentScene == DungeonScene.Instance)
+                    return true;
+                return false;
+            }
+        }
+        public int CurrentPage = 0;
+        public string CurrentPageId => PageIds[CurrentPage];
+        public MenuText Title;
+        public MenuCursor Left;
+        public MenuCursor Right;
+        internal SettingsPageSummaryMenu Preview;
+        public SettingsTitleMenu() : this(MenuLabel.SETTINGS_MENU) { }
+        public SettingsTitleMenu(string label)
+        {
+            Label = label;
+            SetupDefaultSettingsPage();
+
+            Bounds = new Rect(new Loc(16, 8), new Loc(224, VERT_SPACE + GraphicsManager.MenuBG.TileHeight * 2));
+
+            Title = new MenuText(MenuLabel.TITLE, Pages[CurrentPageId].Title, new Loc(Bounds.Width / 2, GraphicsManager.MenuBG.TileHeight+1), DirH.None);
+            Left = new MenuCursor($"{MenuLabel.CURSOR}_LEFT", this, Dir4.Left);
+            Left.Loc = new Loc(GraphicsManager.MenuBG.TileWidth, GraphicsManager.MenuBG.TileHeight + 1);
+            Right = new MenuCursor($"{MenuLabel.CURSOR}_RIGHT", this, Dir4.Right);
+            Right.Loc = new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth - GraphicsManager.Cursor.TileWidth, GraphicsManager.MenuBG.TileHeight+1);
+
+            Elements.Add(Title);
+
+            Preview = new SettingsPageSummaryMenu(this, Pages[CurrentPageId]);
+            SummaryMenus.Add(Preview);
+        }
+
+        private bool changeLanguage = false;
+        private void SetupDefaultSettingsPage()
+        {
+            SettingsPage origin = AddPage(_originId, Text.FormatKey("MENU_SETTINGS_TITLE"));
+
+            List<string> musicChoices = new List<string>();
+            for (int ii = 0; ii <= 10; ii++)
+                musicChoices.Add(ii.ToString());
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_MUSIC"), musicChoices, DiagManager.Instance.CurSettings.BGMBalance, setting => DiagManager.Instance.CurSettings.BGMBalance = setting.CurrentChoice, setting => SoundManager.BGMBalance = setting.CurrentChoice * 0.1f);
+
+            List<string> soundChoices = new List<string>();
+            for (int ii = 0; ii <= 10; ii++)
+                soundChoices.Add(ii.ToString());
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_SOUND"), soundChoices, DiagManager.Instance.CurSettings.SEBalance, setting => DiagManager.Instance.CurSettings.SEBalance = setting.CurrentChoice, setting => SoundManager.SEBalance = setting.CurrentChoice * 0.1f);
+
+            List<string> speedChoices = new List<string>();
+            for (int ii = 0; ii <= (int)Settings.BattleSpeed.VeryFast; ii++)
+                speedChoices.Add(((Settings.BattleSpeed)ii).ToLocal());
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_BATTLE_SPEED"), speedChoices, (int)DiagManager.Instance.CurSettings.BattleFlow, setting => DiagManager.Instance.CurSettings.BattleFlow = (Settings.BattleSpeed)setting.CurrentChoice);
+
+            List<string> textSpeedChoices = new List<string>();
+            for (int ii = 1; ii <= 6; ii++)
+                textSpeedChoices.Add((ii * 0.5).ToString(CultureInfo.InvariantCulture));
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_TEXT_SPEED"), textSpeedChoices, (int)(DiagManager.Instance.CurSettings.TextSpeed * 2) - 1, setting => DiagManager.Instance.CurSettings.TextSpeed = (setting.CurrentChoice + 1) * 0.5);
+
+            List<string> skillChoices = new List<string>();
+            for (int ii = 0; ii <= (int)Settings.SkillDefault.All; ii++)
+                skillChoices.Add(((Settings.SkillDefault)ii).ToLocal());
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_SKILL_DEFAULT"), skillChoices, (int)DiagManager.Instance.CurSettings.DefaultSkills, setting => {
+                DiagManager.Instance.CurSettings.DefaultSkills = (Settings.SkillDefault)setting.CurrentChoice;
+                if (InGame)
+                    DataManager.Instance.Save.UpdateOptions();
+            });
+
+            List<string> minimapChoices = new List<string>();
+            for (int ii = 0; ii < 10; ii++)
+                minimapChoices.Add(String.Format("{0}%", (ii + 1) * 10));
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_MINIMAP_VISIBILITY"), minimapChoices, DiagManager.Instance.CurSettings.Minimap / 10 - 1, setting => DiagManager.Instance.CurSettings.Minimap = (setting.CurrentChoice + 1) * 10);
+
+            List<string> minimapColorChoices = new List<string>();
+            for (int ii = 0; ii <= (int)Settings.MinimapStyle.Blue; ii++)
+                minimapColorChoices.Add(((Settings.MinimapStyle)ii).ToLocal());
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_MINIMAP_COLOR"), minimapColorChoices, (int)DiagManager.Instance.CurSettings.MinimapColor, setting => DiagManager.Instance.CurSettings.MinimapColor = (Settings.MinimapStyle)setting.CurrentChoice);
+
+            List<string> borderChoices = new List<string>();
+            for (int ii = 0; ii < 5; ii++)
+                borderChoices.Add(ii.ToString());
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_BORDER_STYLE"), borderChoices, DiagManager.Instance.CurSettings.Border, setting => DiagManager.Instance.CurSettings.Border = setting.CurrentChoice, setting => MenuBase.BorderStyle = setting.CurrentChoice);
+
+
+            List<string> windowChoices = new List<string>();
+            windowChoices.Add(Text.FormatKey("MENU_SETTINGS_FULL_SCREEN"));
+            for (int ii = 1; ii < 9; ii++)
+                windowChoices.Add(String.Format("{0}x{1}", GraphicsManager.ScreenWidth * ii, GraphicsManager.ScreenHeight * ii));
+            origin.AddSetting(Text.FormatKey("MENU_SETTINGS_WINDOW_SIZE"), windowChoices, DiagManager.Instance.CurSettings.Window, setting =>
+            {
+                DiagManager.Instance.CurSettings.Window = setting.CurrentChoice;
+                GraphicsManager.SetWindowMode(DiagManager.Instance.CurSettings.Window);
+            });
+
+            if (!InGame)
+            {
+                List<string> langChoices = new List<string>();
+                int langIndex = 0;
+                for (int ii = 0; ii < Text.SupportedLangs.Length; ii++)
+                {
+                    langChoices.Add(Text.SupportedLangs[ii].ToName());
+                    if (DiagManager.Instance.CurSettings.Language == Text.SupportedLangs[ii])
+                        langIndex = ii;
+                }
+
+                origin.AddSetting(Text.FormatKey("MENU_SETTINGS_LANGUAGE"), langChoices, langIndex, setting =>
+                {
+                    changeLanguage = DiagManager.Instance.CurSettings.Language != Text.SupportedLangs[setting.CurrentChoice];
+                    DiagManager.Instance.CurSettings.Language = Text.SupportedLangs[setting.CurrentChoice];
+
+                    Text.SetCultureCode(DiagManager.Instance.CurSettings.Language);
+                });
+
+                origin.GlobalSaveAction = OriginGlobalSaveAction;
+            }
+        }
+
+        public void OriginGlobalSaveAction()
+        {
+            DiagManager.Instance.SaveSettings(DiagManager.Instance.CurSettings);
+
+            if (changeLanguage)
+            {
+                //clear menu
+                MenuManager.Instance.ClearMenus();
+                GraphicsManager.ReloadStatic();
+                MenuManager.Instance.AddMenu(MenuManager.Instance.CreateDialogue(Text.FormatKey("DLG_LANGUAGE_SET", DiagManager.Instance.CurSettings.Language.ToName())), false);
+            }
+        }
+
+        public bool HasPage(string key)
+        {
+            return PageIds.Contains(key);
+        }
+
+        //creates the page if absent
+        public SettingsPage AddPage(string key, string title)
+        {
+            if (PageIds.Contains(key)) throw new DuplicateNameException($"Key \"{key}\" already exists");
+
+            PageIds.Add(key);
+            Pages[key] = new(title);
+            PageIds.Sort((s1, s2) =>
+            {
+                //origin must always be at the start
+                if (s1 == _originId) return -1;
+                if (s2 == _originId) return 1;
+                //the rest is in id order
+                return s1.CompareTo(s2);
+            });
+
+            return Pages[key];
+        }
+        public override void Update(InputManager input)
+        {
+            if (!checkedPages)
+            {
+                checkedPages = true;
+                if (Pages.Count > 1)
+                {
+                    Elements.Add(Left);
+                    Elements.Add(Right);
+                }
+                else
+                    MenuManager.Instance.AddMenu(new SettingsPageMenu(this, Pages[CurrentPageId]), true);
+            }
+            else if (Pages.Count == 1)
+            {
+                MenuManager.Instance.RemoveMenu();
+            }
+
+            if (input.JustPressed(FrameInput.InputType.Confirm))
+            {
+                MenuManager.Instance.AddMenu(new SettingsPageMenu(this, Pages[CurrentPageId]), true);
+            }
+            else if(input.JustPressed(FrameInput.InputType.Cancel))
+            {
+                MenuManager.Instance.RemoveMenu();
+            }
+            else if (IsInputting(input, Dir8.Right))
+            {
+                CurrentPage = (CurrentPage + 1) % PageIds.Count;
+                ChoiceChanged();
+                GameManager.Instance.SE("Menu/Skip");
+            }
+            else if (IsInputting(input, Dir8.Left))
+            {
+                CurrentPage = (PageIds.Count + CurrentPage - 1) % PageIds.Count;
+                ChoiceChanged();
+                GameManager.Instance.SE("Menu/Skip");
+            }
+        }
+
+        public void ChoiceChanged()
+        {
+            Title.SetText(Pages[CurrentPageId].Title);
+            Preview.LoadOptions(Pages[CurrentPageId]);
+        }
+    }
+}

--- a/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
@@ -32,7 +32,7 @@ namespace RogueEssence.Menu
     public class SettingsPage
     {
         public string Title = "";
-        public List<SettingData> Choices = new();
+        public List<SettingData> Choices = new List<SettingData>();
         public Action GlobalSaveAction;
         public SettingsPage(string title)
         {
@@ -58,8 +58,8 @@ namespace RogueEssence.Menu
     public class SettingsTitleMenu : InteractableMenu
     {
         private static string _originId = PathMod.BaseNamespace;
-        private readonly List<string> PageIds = new();
-        private readonly Dictionary<string, SettingsPage> Pages = new();
+        private readonly List<string> PageIds = new List<string>();
+        private readonly Dictionary<string, SettingsPage> Pages = new Dictionary<string, SettingsPage>();
         private bool checkedPages = false;
         public static bool InGame
         {

--- a/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
@@ -1,4 +1,5 @@
-﻿using RogueElements;
+﻿using NLua;
+using RogueElements;
 using RogueEssence.Content;
 using RogueEssence.Data;
 using RogueEssence.Dungeon;
@@ -36,6 +37,13 @@ namespace RogueEssence.Menu
         public SettingsPage(string title)
         {
             Title = title;
+        }
+        public void AddSetting(string name, LuaTable options, int defaultValue, Action<MenuSetting> action, Action<MenuSetting> settingChangedAction = null)
+        {
+            Object[] arr = new Object[options.Values.Count];
+            options.Values.CopyTo(arr, 0);
+            List<string> list = arr.Select(a => a.ToString()).ToList();
+            AddSetting(name, list, defaultValue, action, settingChangedAction);
         }
         public void AddSetting(string name, string[] options, int defaultValue, Action<MenuSetting> action, Action<MenuSetting> settingChangedAction = null)
         {

--- a/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsTitleMenu.cs
@@ -57,7 +57,7 @@ namespace RogueEssence.Menu
 
     public class SettingsTitleMenu : InteractableMenu
     {
-        private static string _originId = "origin";
+        private static string _originId = PathMod.BaseNamespace;
         private readonly List<string> PageIds = new();
         private readonly Dictionary<string, SettingsPage> Pages = new();
         private bool checkedPages = false;

--- a/RogueEssence/Menu/Top/ModDiffSummary.cs
+++ b/RogueEssence/Menu/Top/ModDiffSummary.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using RogueElements;
 using RogueEssence.Content;
-using RogueEssence.Data;
-using Microsoft.Xna.Framework;
 using System;
 
 namespace RogueEssence.Menu


### PR DESCRIPTION
- Full settings menu rework using a title window and a page window
- New pages can be injected using OnAddMenu on the esttings title (the label is just "SETTINGS_MENU")
- SettingsTitlemenu.AddPage returns a new page. SettingsPage.AddSetting registers new settings
- Every setting contains a save action and an optional change action
- Pages can have a global save step that is ran after all settings are saved