### PR TITLE
Changed the program to open paths from `mimeopen` to `xdg-open`

### DIFF
--- a/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/ZoneDataEditor.cs
+++ b/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/ZoneDataEditor.cs
@@ -41,7 +41,7 @@ namespace RogueEssence.Dev
                         if (OperatingSystem.IsWindows())
                             Process.Start("explorer.exe", zonescriptdir);
                         else if (OperatingSystem.IsLinux())
-                            Process.Start("mimeopen", zonescriptdir);
+                            Process.Start("xdg-open", zonescriptdir);
                         else if (OperatingSystem.IsMacOS())
                             Process.Start("open", zonescriptdir);
                         else

--- a/RogueEssence.Editor.Avalonia/ViewModels/GroundEditForm/GroundTabScriptViewModel.cs
+++ b/RogueEssence.Editor.Avalonia/ViewModels/GroundEditForm/GroundTabScriptViewModel.cs
@@ -52,7 +52,7 @@ namespace RogueEssence.Dev.ViewModels
                     if (OperatingSystem.IsWindows())
                         Process.Start("explorer.exe", mapscriptdir);
                     else if (OperatingSystem.IsLinux())
-                        Process.Start("mimeopen", mapscriptdir);
+                        Process.Start("xdg-open", mapscriptdir);
                     else if (OperatingSystem.IsMacOS())
                         Process.Start("open", mapscriptdir);
                     else


### PR DESCRIPTION
There is a button in two different screens of the Dev Controls that says "Open Script Folder". The purpose of this button is to open a filesystem path on an external process. For that to happen, the following code is executed:

```cs
if (OperatingSystem.IsWindows())
    Process.Start("explorer.exe", zonescriptdir);
else if (OperatingSystem.IsLinux())
    Process.Start("mimeopen", zonescriptdir);
else if (OperatingSystem.IsMacOS())
    Process.Start("open", zonescriptdir);
```

In Linux based operating systems, the program used here is `mimeopen`. The problem with it, is that it is **not present** in some common distributions like Fedora or OpenSUSE. It is possible to download it, but this could be not straightforward for people that are not used to these operating systems, as they need to interpret the error trace that shows in the terminal when not having `mimeopen` installed, and then search for the name of the package that provides the `mimeopen` program.

The purpose of this PR is to change the program used for opening paths to `xdg-open`, which is more standard and is always installed in every major Linux distribution. This way, the button will work "out of the box" in many Linux distributions without installing additional software.

Feel free to discuss this proposal :)