### PR TITLE
Add FormIntrinsicSlot property

### DIFF
--- a/RogueEssence/Dungeon/Characters/CharData.cs
+++ b/RogueEssence/Dungeon/Characters/CharData.cs
@@ -228,6 +228,10 @@ namespace RogueEssence.Dungeon
 
         public virtual void Promote(MonsterID data)
         {
+            if (FormIntrinsicSlot < 0)
+            {
+                FormIntrinsicSlot = GetFormIntrinsicSlot(BaseIntrinsics[0]);
+            }
             int newIndex = FormIntrinsicSlot;
 
             BaseForm = data;

--- a/RogueEssence/Dungeon/Characters/CharData.cs
+++ b/RogueEssence/Dungeon/Characters/CharData.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using NLua;
 using RogueEssence.Data;

--- a/RogueEssence/Dungeon/Characters/CharData.cs
+++ b/RogueEssence/Dungeon/Characters/CharData.cs
@@ -176,6 +176,15 @@ namespace RogueEssence.Dungeon
             LuaDataTable = other.LuaDataTable;
         }
 
+        public void SetBaseIntrinsic(string intrinsic, int slot = 0)
+        {
+            if(slot >= MAX_INTRINSIC_SLOTS)
+                throw new Exception("Slot number out of bounds!");
+
+            BaseIntrinsics[slot] = intrinsic;
+            if (slot == 0)
+                FormIntrinsicSlot = GetFormIntrinsicSlot(intrinsic);
+        }
 
         public bool HasBaseIntrinsic(string intrinsic)
         {

--- a/RogueEssence/Dungeon/Characters/CharData.cs
+++ b/RogueEssence/Dungeon/Characters/CharData.cs
@@ -65,20 +65,7 @@ namespace RogueEssence.Dungeon
 
         [JsonConverter(typeof(IntrinsicListConverter))]
         public List<string> BaseIntrinsics;
-        private int _intrinsicSlot = -1;
-        public int FormIntrinsicSlot {
-            get
-            {
-                if (_intrinsicSlot<0)
-                {
-                    if (BaseForm.Species == null)
-                        return 0;
-                    _intrinsicSlot = GetFormIntrinsicSlot(BaseIntrinsics[0]);
-                }
-                return _intrinsicSlot;
-            }
-            set => _intrinsicSlot = Math.Max(0, Math.Min(value, 3));
-        }
+        public int FormIntrinsicSlot = -1;
 
         [JsonConverter(typeof(RelearnableConverter))]
         public Dictionary<string, bool> Relearnables;
@@ -167,6 +154,7 @@ namespace RogueEssence.Dungeon
                 BaseSkills.Add(new SlotSkill(skill));
             BaseIntrinsics = new List<string>();
             BaseIntrinsics.AddRange(other.BaseIntrinsics);
+            FormIntrinsicSlot = other.FormIntrinsicSlot;
             Relearnables = new Dictionary<string, bool>();
             foreach (string key in other.Relearnables.Keys)
                 Relearnables[key] = other.Relearnables[key];
@@ -217,7 +205,7 @@ namespace RogueEssence.Dungeon
             MonsterData dex = DataManager.Instance.GetMonster(BaseForm.Species);
             BaseMonsterForm form = dex.Forms[BaseForm.Form];
 
-            int index = _intrinsicSlot;
+            int index = FormIntrinsicSlot;
             if (form.Intrinsic1 == intrinsic)
                 index = 0;
             else if (form.Intrinsic2 == intrinsic)

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -482,6 +482,7 @@ namespace RogueEssence.Dungeon
 
             for (int ii = 0; ii < CharData.MAX_INTRINSIC_SLOTS; ii++)
                 character.BaseIntrinsics[ii] = this.BaseIntrinsics[ii];
+            character.FormIntrinsicSlot = this.FormIntrinsicSlot;
 
             Character new_mob = new Character(character);
             team.Players.Add(new_mob);

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -1218,6 +1218,8 @@ namespace RogueEssence.Dungeon
                 throw new Exception("No more room for intrinsics!");
 
             BaseIntrinsics[slot] = intrinsicNum;
+            if (slot == 0)
+                FormIntrinsicSlot = GetFormIntrinsicSlot(intrinsicNum);
             for (int ii = Intrinsics.Count - 1; ii >= 0; ii--)
             {
                 if (Intrinsics[ii].BackRef == slot)

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -1211,9 +1211,7 @@ namespace RogueEssence.Dungeon
             if (slot == -1)
                 throw new Exception("No more room for intrinsics!");
 
-            BaseIntrinsics[slot] = intrinsicNum;
-            if (slot == 0)
-                FormIntrinsicSlot = GetFormIntrinsicSlot(intrinsicNum);
+            SetBaseIntrinsic(intrinsicNum, slot);
             for (int ii = Intrinsics.Count - 1; ii >= 0; ii--)
             {
                 if (Intrinsics[ii].BackRef == slot)

--- a/RogueEssence/Dungeon/Characters/Character.cs
+++ b/RogueEssence/Dungeon/Characters/Character.cs
@@ -642,14 +642,7 @@ namespace RogueEssence.Dungeon
             Element2 = DataManager.Instance.GetMonster(CurrentForm.Species).Forms[CurrentForm.Form].Element2;
 
             //remap intrinsic to be the corresponding intrinsic of the new form
-            MonsterData dex = DataManager.Instance.GetMonster(BaseForm.Species);
-            BaseMonsterForm form = dex.Forms[BaseForm.Form];
-
-            int prevIndex = 0;
-            if (form.Intrinsic2 == BaseIntrinsics[0])
-                prevIndex = 1;
-            else if (form.Intrinsic3 == BaseIntrinsics[0])
-                prevIndex = 2;
+            int prevIndex = FormIntrinsicSlot;
 
             MonsterData newDex = DataManager.Instance.GetMonster(CurrentForm.Species);
             BaseMonsterForm newForm = newDex.Forms[CurrentForm.Form];

--- a/RogueEssence/Dungeon/Team.cs
+++ b/RogueEssence/Dungeon/Team.cs
@@ -620,9 +620,9 @@ namespace RogueEssence.Dungeon
                 character.BaseForm.Gender = dex.Forms[formData.Form].RollGender(rand);
             
             if (String.IsNullOrEmpty(intrinsic))
-                character.BaseIntrinsics[0] = formEntry.RollIntrinsic(rand, 2);
+                character.SetBaseIntrinsic(formEntry.RollIntrinsic(rand, 2));
             else
-                character.BaseIntrinsics[0] = intrinsic;
+                character.SetBaseIntrinsic(intrinsic);
 
             if (personality == -1)
                 character.Discriminator = rand.Next();

--- a/RogueEssence/LevelGen/Spawning/MobSpawn/MobSpawn.cs
+++ b/RogueEssence/LevelGen/Spawning/MobSpawn/MobSpawn.cs
@@ -124,9 +124,9 @@ namespace RogueEssence.LevelGen
                 character.BaseSkills[ii] = new SlotSkill(final_skills[ii]);
 
             if (String.IsNullOrEmpty(Intrinsic))
-                character.BaseIntrinsics[0] = formEntry.RollIntrinsic(map.Rand, 2);
+                character.SetBaseIntrinsic(formEntry.RollIntrinsic(map.Rand, 2));
             else
-                character.BaseIntrinsics[0] = Intrinsic;
+                character.SetBaseIntrinsic(Intrinsic);
 
             character.Discriminator = map.Rand.Next();
 


### PR DESCRIPTION
- Add a helper property called `FormIntrinsicSlot`
  - This property starts not loaded. Its value is calculated as soon as it is read for the first time.
  - This was necessary because a `CharData`'s constructor does not initialize its BaseForm.
- `FormIntrinsicSlot` stores a character's "natural" `BaseIntrinsic[0]` index in respect to its form's intrinsic slots. If a character is promoted, it will always try to assume the intrinsic corresponding to that value, if possible.
  - If the first time a character's `FormIntrinsicSlot` is read is when its `BaseIntrinsic[0]` is valid for its form, its slot number will be read and stored normally
  - If the first time a character's `FormIntrinsicSlot` is read is when its `BaseIntrinsic[0]` is not valid for its form, `FormIntrinsicSlot` will be set to a randomly generted number between 0 and 2 (both included). The invalid intrinsic will not be touched at all, so that characters with invalid intrinsics can still be spawned just fine
- Once `FormIntrinsicSlot` is set, using an Ability Capsule is the only way to change its value during normal gameplay.