### PR TITLE
Label display

### DIFF
--- a/RogueEssence/Dungeon/BaseDungeonScene.cs
+++ b/RogueEssence/Dungeon/BaseDungeonScene.cs
@@ -467,8 +467,8 @@ namespace RogueEssence.Dungeon
             {
                 Loc loc = ScreenCoordsToGroundCoords(MouseLoc);
                 Loc tileLoc = ScreenCoordsToMapCoords(MouseLoc);
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 102, String.Format("Mouse  X:{0:D3} Y:{1:D3}", loc.X, loc.Y), null, DirV.Up, DirH.Left, Color.White);
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 112, String.Format("M Tile X:{0:D3} Y:{1:D3}", tileLoc.X, tileLoc.Y), null, DirV.Up, DirH.Left, Color.White);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 112, String.Format("Mouse  X:{0:D3} Y:{1:D3}", loc.X, loc.Y), null, DirV.Up, DirH.Left, Color.White);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 122, String.Format("M Tile X:{0:D3} Y:{1:D3}", tileLoc.X, tileLoc.Y), null, DirV.Up, DirH.Left, Color.White);
             }
         }
 

--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -1474,7 +1474,7 @@ namespace RogueEssence.Dungeon
             GraphicsManager.SysFont.DrawText(spriteBatch, GraphicsManager.WindowWidth - 2, 52, String.Format("Total {0:D6}", DataManager.Instance.Save.TotalTurns), null, DirV.Up, DirH.Right, Color.White);
 
             if (SeeAll)
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 92, "See All", null, DirV.Up, DirH.Left, Color.LightYellow);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 102, "See All", null, DirV.Up, DirH.Left, Color.LightYellow);
 
             if (FocusedCharacter != null)
             {

--- a/RogueEssence/Ground/BaseGroundScene.cs
+++ b/RogueEssence/Ground/BaseGroundScene.cs
@@ -336,9 +336,9 @@ namespace RogueEssence.Ground
                 Loc loc = ScreenCoordsToGroundCoords(MouseLoc);
                 Loc blockLoc = ScreenCoordsToBlockCoords(MouseLoc);
                 Loc tileLoc = ScreenCoordsToMapCoords(MouseLoc);
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 102, String.Format("MOUSE  X:{0:D3} Y:{1:D3}", loc.X, loc.Y), null, DirV.Up, DirH.Left, Color.White);
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 112, String.Format("M WALL X:{0:D3} Y:{1:D3}", blockLoc.X, blockLoc.Y), null, DirV.Up, DirH.Left, Color.White);
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 122, String.Format("M TILE X:{0:D3} Y:{1:D3}", tileLoc.X, tileLoc.Y), null, DirV.Up, DirH.Left, Color.White);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 112, String.Format("MOUSE  X:{0:D3} Y:{1:D3}", loc.X, loc.Y), null, DirV.Up, DirH.Left, Color.White);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 122, String.Format("M WALL X:{0:D3} Y:{1:D3}", blockLoc.X, blockLoc.Y), null, DirV.Up, DirH.Left, Color.White);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 132, String.Format("M TILE X:{0:D3} Y:{1:D3}", tileLoc.X, tileLoc.Y), null, DirV.Up, DirH.Left, Color.White);
             }
         }
 

--- a/RogueEssence/Ground/GroundScene.cs
+++ b/RogueEssence/Ground/GroundScene.cs
@@ -396,7 +396,7 @@ namespace RogueEssence.Ground
             GraphicsManager.SysFont.DrawText(spriteBatch, GraphicsManager.WindowWidth - 2, 32, String.Format("Z:{0:D3} S:{1:D3} M:{2:D3}", ZoneManager.Instance.CurrentZoneID, ZoneManager.Instance.CurrentMapID.Segment, ZoneManager.Instance.CurrentMapID.ID), null, DirV.Up, DirH.Right, Color.White);
 
             if (FreeCamCenter.HasValue)
-                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 92, "Free Cam", null, DirV.Up, DirH.Left, Color.LightYellow);
+                GraphicsManager.SysFont.DrawText(spriteBatch, 2, 102, "Free Cam", null, DirV.Up, DirH.Left, Color.LightYellow);
 
             if (FocusedCharacter != null)
             {

--- a/RogueEssence/Lua/LuaEngine.cs
+++ b/RogueEssence/Lua/LuaEngine.cs
@@ -1932,12 +1932,6 @@ namespace RogueEssence.Script
         /// </summary>
         public void OnAddMenu(IInteractable menu)
         {
-            if (menu is InteractableMenu interactable && ((ILabeled)interactable).HasLabel())
-            {
-                DiagManager.Instance.LogInfo("Opening labeled menu...");
-                string type = interactable is MultiPageMenu ? "MultiPageMenu" : interactable is ChoiceMenu ? "ChoiceMenu" : "InteractableMenu";
-                DiagManager.Instance.LogInfo($"Menu Type: {type}. Label: {interactable.Label}");
-            }
             m_scrsvc.Publish(EServiceEvents.AddMenu.ToString(), menu);
         }
 

--- a/RogueEssence/Menu/ChoiceMenu.cs
+++ b/RogueEssence/Menu/ChoiceMenu.cs
@@ -7,6 +7,18 @@ namespace RogueEssence.Menu
     {
         public List<IMenuElement> NonChoices { get { return Elements; } }
         public List<IChoosable> Choices;
+        public IChoosable Hovered
+        {
+            get
+            {
+                foreach (IChoosable choice in Choices)
+                {
+                    if (choice.Hovered)
+                        return choice;
+                }
+                return null;
+            }
+        }
 
         protected MenuCursor cursor;
 

--- a/RogueEssence/Menu/MenuElements/IChoosable.cs
+++ b/RogueEssence/Menu/MenuElements/IChoosable.cs
@@ -6,6 +6,7 @@ namespace RogueEssence.Menu
     {
         Rect Bounds { get; set; }
         bool Selected { get; }
+        bool Hovered { get; }
 
         //chosen by clicking
         void OnMouseState(bool clicked);

--- a/RogueEssence/Menu/MenuElements/MenuChoice.cs
+++ b/RogueEssence/Menu/MenuElements/MenuChoice.cs
@@ -15,6 +15,7 @@ namespace RogueEssence.Menu
 
         public bool Enabled;
         public bool Selected { get; private set; }
+        public bool Hovered => hover;
 
         private bool hover;
         private bool click;

--- a/RogueEssence/Menu/MenuElements/MenuSetting.cs
+++ b/RogueEssence/Menu/MenuElements/MenuSetting.cs
@@ -16,6 +16,7 @@ namespace RogueEssence.Menu
 
         public Rect Bounds { get; set; }
         public bool Selected { get; private set; }
+        public bool Hovered { get; private set; }
 
         public Action ChoiceAction;
 
@@ -69,7 +70,7 @@ namespace RogueEssence.Menu
         public void OnSelect(bool select) { }
 
         //selected by mouse
-        public void OnHoverChanged(bool hover) { }
+        public void OnHoverChanged(bool hover) { Hovered = hover; }
 
         //chosen by confirm button
         public void OnConfirm()

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -1402,6 +1402,11 @@ namespace RogueEssence
                     }
                     GraphicsManager.SysFont.DrawText(spriteBatch, 2, 72, String.Format("MENU: {0} {1}", menu.Label, type), null, DirV.Up, DirH.Left, Color.White);
                     GraphicsManager.SysFont.DrawText(spriteBatch, 2, 82, String.Format("MOUSE MENU X:{0:D3} Y:{1:D3}", menuLoc.Value.X, menuLoc.Value.Y), null, DirV.Up, DirH.Left, Color.White);
+                    if(menu is ChoiceMenu cMenu)
+                    {
+                        IChoosable hover = cMenu.Hovered;
+                        GraphicsManager.SysFont.DrawText(spriteBatch, 2, 92, String.Format("HOVER OPTION: {0}", hover is null ? "" : hover.Label), null, DirV.Up, DirH.Left, Color.White);
+                    }
                 }
             }
 

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -1393,7 +1393,14 @@ namespace RogueEssence
                 MenuManager.Instance.GetMenuCoord(MetaInputManager.MouseLoc, out menu, out menuLoc);
                 if (menu != null)
                 {
-                    GraphicsManager.SysFont.DrawText(spriteBatch, 2, 72, String.Format("MENU: {0}", menu.Label), null, DirV.Up, DirH.Left, Color.White);
+                    string type = "";
+                    if (menu.HasLabel())
+                    {
+                        type = menu is MultiPageMenu ? "(MultiPage)" :
+                            menu is ChoiceMenu ? "(Choice)" :
+                            menu is InteractableMenu ? "(Interactable)" : "";
+                    }
+                    GraphicsManager.SysFont.DrawText(spriteBatch, 2, 72, String.Format("MENU: {0} {1}", menu.Label, type), null, DirV.Up, DirH.Left, Color.White);
                     GraphicsManager.SysFont.DrawText(spriteBatch, 2, 82, String.Format("MOUSE MENU X:{0:D3} Y:{1:D3}", menuLoc.Value.X, menuLoc.Value.Y), null, DirV.Up, DirH.Left, Color.White);
                 }
             }


### PR DESCRIPTION
Move menu type display to dev mode F1 overlay and show hovered choice's label as well
Yes i am aware i wrote F2 in the commit, don't worry about it
End result:
![immagine](https://github.com/user-attachments/assets/e4810e0d-87fb-4127-90f3-2cbfda1d1225)
