### PR TITLE
Improvement: Console Constant Timestamp Length

### DIFF
--- a/RogueEssence/DiagManager.cs
+++ b/RogueEssence/DiagManager.cs
@@ -120,14 +120,14 @@ namespace RogueEssence
             LogError(ex);
             if (ListenGen)
             {
-                logMsgs.Add(String.Format("[{0}] Mapgen: {1}: {2}", String.Format("{0:yyyy/MM/dd HH:mm:ss.FFF}", DateTime.Now), ex.GetType().ToString(), ex.Message));
+                logMsgs.Add(String.Format("[{0}] Mapgen: {1}: {2}", String.Format("{0:yyyy/MM/dd HH:mm:ss.fff}", DateTime.Now), ex.GetType().ToString(), ex.Message));
             }
         }
         private void logRogueElements(string msg)
         {
             if (ListenGen)
             {
-                logMsgs.Add(String.Format("[{1}] Mapgen: {0}", msg, String.Format("{0:yyyy/MM/dd HH:mm:ss.FFF}", DateTime.Now)));
+                logMsgs.Add(String.Format("[{1}] Mapgen: {0}", msg, String.Format("{0:yyyy/MM/dd HH:mm:ss.fff}", DateTime.Now)));
             }
         }
 
@@ -253,7 +253,7 @@ namespace RogueEssence
                 try
                 {
                     StringBuilder errorMsg = new StringBuilder();
-                    errorMsg.Append(String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.FFF}", DateTime.Now), exception.Message));
+                    errorMsg.Append(String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.fff}", DateTime.Now), exception.Message));
                     errorMsg.Append("\n");
                     Exception innerException = exception;
                     int depth = 0;
@@ -298,7 +298,7 @@ namespace RogueEssence
         {
             lock (lockObj)
             {
-                string fullMsg = String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.FFF}", DateTime.Now), diagInfo);
+                string fullMsg = String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.fff}", DateTime.Now), diagInfo);
                 if (DevMode)
                 {
                     Console.WriteLine(fullMsg);

--- a/WaypointServer/DiagManager.cs
+++ b/WaypointServer/DiagManager.cs
@@ -36,7 +36,7 @@ namespace WaypointServer
             Errors++;
 
             StringBuilder errorMsg = new StringBuilder();
-            errorMsg.Append(String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.FFF}", DateTime.Now), exception.Message));
+            errorMsg.Append(String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.fff}", DateTime.Now), exception.Message));
             errorMsg.Append("\n");
             Exception innerException = exception;
             int depth = 0;
@@ -70,7 +70,7 @@ namespace WaypointServer
 
         public void LogInfo(string diagInfo)
         {
-            string fullMsg = String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.FFF}", DateTime.Now), diagInfo);
+            string fullMsg = String.Format("[{0}] {1}", String.Format("{0:yyyy/MM/dd HH:mm:ss.fff}", DateTime.Now), diagInfo);
 
             try
             {


### PR DESCRIPTION
In **console**, when using for example the **Lua** function **PrintInfo**,
internally it calls **LogInfo** from "**DiagManager**", and that class uses this **format: FFF**
which has **variable length**, **instead of fff**, which has a **constant length** 3 chars,
as seen here: https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings

## "fff"	The milliseconds in a date and time value.
**Value  != 0:** 6/15/2009 13:45:30.617 -> 617
**Value == 0:** 6/15/2009 13:45:30.0005 -> **000**

## "FFF"	If non-zero, the milliseconds in a date and time value.
**Value  != 0:** 2009-06-15T13:45:30.6170000 -> 617
**Value == 0:** 2009-06-15T13:45:30.0005000 -> **(no output)**
