### PR TITLE
Give most non-Action menu proprties a public getter

### DIFF
--- a/RogueEssence/Menu/Items/BuyChosenMenu.cs
+++ b/RogueEssence/Menu/Items/BuyChosenMenu.cs
@@ -8,8 +8,16 @@ namespace RogueEssence.Menu
     public class BuyChosenMenu : SingleStripMenu
     {
 
-        private int origIndex;
+        public int origIndex {get; private set;}
         private List<int> selections;
+        public List<int> Selections {
+            get
+            {
+                List<int> newList = new List<int>();
+                newList.AddRange(selections);
+                return newList;
+            }
+        }
         private OnMultiChoice action;
 
         public BuyChosenMenu(List<int> selections, int origIndex, string itemID, OnMultiChoice chooseSlots) :

--- a/RogueEssence/Menu/Items/DepositChosenMenu.cs
+++ b/RogueEssence/Menu/Items/DepositChosenMenu.cs
@@ -10,8 +10,16 @@ namespace RogueEssence.Menu
     public class DepositChosenMenu : SingleStripMenu
     {
 
-        private int origIndex;
+        public int origIndex {get; private set;}
         private List<InvSlot> selections;
+        public List<InvSlot> Selections {
+            get
+            {
+                List<InvSlot> newList = new List<InvSlot>();
+                selections.ForEach(elem => newList.Add(new InvSlot(elem.IsEquipped, elem.Slot)));
+                return newList;
+            }
+        }
 
         public DepositChosenMenu(List<InvSlot> selections, int origIndex) : this(MenuLabel.DEPOSIT_CHOSEN_MENU, selections, origIndex) { }
         public DepositChosenMenu(string label, List<InvSlot> selections, int origIndex)

--- a/RogueEssence/Menu/Items/ItemChosenMenu.cs
+++ b/RogueEssence/Menu/Items/ItemChosenMenu.cs
@@ -12,8 +12,8 @@ namespace RogueEssence.Menu
     public class ItemChosenMenu : SingleStripMenu
     {
 
-        private int slot;
-        private bool held;
+        public int slot {get; private set;}
+        public bool held {get; private set;}
 
         public ItemChosenMenu(int slot, bool held) : this(MenuLabel.ITEM_CHOSEN_MENU ,slot, held) { }
         public ItemChosenMenu(string label, int slot, bool held)

--- a/RogueEssence/Menu/Items/SellChosenMenu.cs
+++ b/RogueEssence/Menu/Items/SellChosenMenu.cs
@@ -10,8 +10,16 @@ namespace RogueEssence.Menu
     public class SellChosenMenu : SingleStripMenu
     {
 
-        private int origIndex;
+        public int origIndex {get; private set;}
         private List<InvSlot> selections;
+        public List<InvSlot> Selections {
+            get
+            {
+                List<InvSlot> newList = new List<InvSlot>();
+                selections.ForEach(elem => newList.Add(new InvSlot(elem.IsEquipped, elem.Slot)));
+                return newList;
+            }
+        }
         private SellMenu.OnChooseSlots action;
 
         public SellChosenMenu(List<InvSlot> selections, int origIndex, SellMenu.OnChooseSlots chooseSlots) :

--- a/RogueEssence/Menu/Items/TeachMenu.cs
+++ b/RogueEssence/Menu/Items/TeachMenu.cs
@@ -17,9 +17,9 @@ namespace RogueEssence.Menu
         MenuText[] Skills;
         MenuText[] SkillCharges;
 
-        private int slot;
-        private bool held;
-        private int commandIdx;
+        public int slot {get; private set;}
+        public bool held {get; private set;}
+        public int commandIdx {get; private set;}
 
         public TeachMenu(int slot, bool held, int commandIdx) : this(MenuLabel.TEACH_MENU, slot, held, commandIdx) { }
         public TeachMenu(string label, int slot, bool held, int commandIdx)

--- a/RogueEssence/Menu/Items/WithdrawChosenMenu.cs
+++ b/RogueEssence/Menu/Items/WithdrawChosenMenu.cs
@@ -11,8 +11,16 @@ namespace RogueEssence.Menu
     public class WithdrawChosenMenu : SingleStripMenu
     {
 
-        private int origIndex;
+        public int origIndex {get; private set;}
         private List<WithdrawSlot> selections;
+        public List<WithdrawSlot> Selections {
+            get
+            {
+                List<WithdrawSlot> newList = new List<WithdrawSlot>();
+                selections.ForEach(elem => newList.Add(new WithdrawSlot(elem.IsBox, elem.ItemID, elem.BoxSlot)));
+                return newList;
+            }
+        }
         WithdrawMenu.OnWithdrawChoice storageChoice;
         bool continueOnChoose;
 

--- a/RogueEssence/Menu/Records/ReplayChosenMenu.cs
+++ b/RogueEssence/Menu/Records/ReplayChosenMenu.cs
@@ -14,7 +14,7 @@ namespace RogueEssence.Menu
     public class ReplayChosenMenu : SingleStripMenu
     {
 
-        private string recordDir;
+        public string recordDir {get; private set;}
 
         public ReplayChosenMenu(string dir) : this(MenuLabel.REPLAY_CHOSEN_MENU, dir) { }
         public ReplayChosenMenu(string label, string dir)

--- a/RogueEssence/Menu/Rogue/QuicksaveChosenMenu.cs
+++ b/RogueEssence/Menu/Rogue/QuicksaveChosenMenu.cs
@@ -12,7 +12,7 @@ namespace RogueEssence.Menu
     public class QuicksaveChosenMenu : SingleStripMenu
     {
 
-        private string recordDir;
+        public string recordDir {get; private set;}
 
         public QuicksaveChosenMenu(string dir) : this(MenuLabel.ROGUE_QUICKSAVE_CHOSEN_MENU, dir) { }
         public QuicksaveChosenMenu(string label, string dir)

--- a/RogueEssence/Menu/Settings/SettingsPageMenu.cs
+++ b/RogueEssence/Menu/Settings/SettingsPageMenu.cs
@@ -39,7 +39,7 @@ namespace RogueEssence.Menu
         {
             foreach (IChoosable element in Choices)
             {
-                if(element is MenuSetting || SettingsData.ContainsKey((MenuSetting)element))
+                if(element is MenuSetting && SettingsData.ContainsKey((MenuSetting)element))
                 {
                     MenuSetting setting = element as MenuSetting;
                     SettingsData[setting].SaveAction.Invoke(setting);

--- a/RogueEssence/Menu/Skills/IntrinsicForgetMenu.cs
+++ b/RogueEssence/Menu/Skills/IntrinsicForgetMenu.cs
@@ -11,7 +11,7 @@ namespace RogueEssence.Menu
     {
         OnChooseSlot chooseSlotAction;
         Action refuseAction;
-        Character player;
+        public Character player {get; private set;}
 
         SummaryMenu summaryMenu;
         DialogueText Description;

--- a/RogueEssence/Menu/Skills/IntrinsicRecallMenu.cs
+++ b/RogueEssence/Menu/Skills/IntrinsicRecallMenu.cs
@@ -14,7 +14,7 @@ namespace RogueEssence.Menu
         string[] intrinsicChoices;
         OnChooseSlot chooseSlotAction;
         Action refuseAction;
-        Character player;
+        public Character player {get; private set;}
 
         SummaryMenu summaryMenu;
         DialogueText Description;

--- a/RogueEssence/Menu/Skills/SkillChosenMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillChosenMenu.cs
@@ -10,10 +10,10 @@ namespace RogueEssence.Menu
 {
     public class SkillChosenMenu : SingleStripMenu
     {
-        private string parentLabel;
+        public string parentLabel {get; private set;}
 
-        private int teamIndex;
-        private int skillSlot;
+        public int teamIndex {get; private set;}
+        public int skillSlot {get; private set;}
 
 
         public SkillChosenMenu(string parentLabel, int teamIndex, int skillSlot) : this(MenuLabel.SKILL_CHOSEN_MENU, parentLabel, teamIndex, skillSlot) { }

--- a/RogueEssence/Menu/Skills/SkillForgetMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillForgetMenu.cs
@@ -13,7 +13,7 @@ namespace RogueEssence.Menu
     {
         OnChooseSlot chooseSlotAction;
         Action refuseAction;
-        Character player;
+        public Character player {get; private set;}
 
         SkillSummary summaryMenu;
 

--- a/RogueEssence/Menu/Skills/SkillRecallMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillRecallMenu.cs
@@ -14,7 +14,7 @@ namespace RogueEssence.Menu
         string[] forgottenSkills;
         OnChooseSlot chooseSlotAction;
         Action refuseAction;
-        Character player;
+        public Character player {get; private set;}
 
         SkillSummary summaryMenu;
 

--- a/RogueEssence/Menu/Skills/SkillReplaceMenu.cs
+++ b/RogueEssence/Menu/Skills/SkillReplaceMenu.cs
@@ -13,8 +13,8 @@ namespace RogueEssence.Menu
     {
         OnChooseSlot learnAction;
         Action refuseAction;
-        Character player;
-        string skillNum;
+        public Character player {get; private set;}
+        public string skillNum {get; private set;}
 
         SkillSummary summaryMenu;
 

--- a/RogueEssence/Menu/Team/AssemblyChosenMenu.cs
+++ b/RogueEssence/Menu/Team/AssemblyChosenMenu.cs
@@ -11,10 +11,10 @@ namespace RogueEssence.Menu
 {
     public class AssemblyChosenMenu : SingleStripMenu
     {
-        private int teamSlot;
-        private bool assembly;
+        public int teamSlot {get; private set;}
+        public bool assembly {get; private set;}
 
-        private AssemblyMenu baseMenu;
+        public AssemblyMenu baseMenu {get; private set;}
 
         public AssemblyChosenMenu(int teamSlot, bool assembly, AssemblyMenu baseMenu) : this(MenuLabel.ASSEMBLY_CHOSEN_MENU, teamSlot, assembly, baseMenu) { }
         public AssemblyChosenMenu(string label, int teamSlot, bool assembly, AssemblyMenu baseMenu)

--- a/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
+++ b/RogueEssence/Menu/Team/MemberFeaturesMenu.cs
@@ -10,11 +10,11 @@ namespace RogueEssence.Menu
 {
     public class MemberFeaturesMenu : InteractableMenu
     {
-        Team team;
-        int teamSlot;
-        bool assembly;
-        bool allowAssembly;
-        bool guest;
+        public Team team {get; private set;}
+        public int teamSlot {get; private set;}
+        public bool assembly {get; private set;}
+        public bool allowAssembly {get; private set;}
+        public bool guest {get; private set;}
 
         public MenuText Title;
         public MenuText PageText;

--- a/RogueEssence/Menu/Team/MemberInfoMenu.cs
+++ b/RogueEssence/Menu/Team/MemberInfoMenu.cs
@@ -10,11 +10,11 @@ namespace RogueEssence.Menu
 {
     public class MemberInfoMenu : InteractableMenu
     {
-        Team team;
-        int teamSlot;
-        bool assembly;
-        bool allowAssembly;
-        bool guest;
+        public Team team {get; private set;}
+        public int teamSlot {get; private set;}
+        public bool assembly {get; private set;}
+        public bool allowAssembly {get; private set;}
+        public bool guest {get; private set;}
 
         public MenuText Title;
         public MenuText PageText;

--- a/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
+++ b/RogueEssence/Menu/Team/MemberLearnsetMenu.cs
@@ -14,11 +14,11 @@ namespace RogueEssence.Menu
         public static readonly int SLOTS_PER_PAGE = 6;
         private List<string> Skills = new List<string>();
 
-        Team team;
-        int teamSlot;
-        bool assembly;
-        bool allowAssembly;
-        bool guest;
+        public Team team {get; private set;}
+        public int teamSlot {get; private set;}
+        public bool assembly {get; private set;}
+        public bool allowAssembly {get; private set;}
+        public bool guest {get; private set;}
 
         SkillSummary summaryMenu;
 

--- a/RogueEssence/Menu/Team/MemberStatsMenu.cs
+++ b/RogueEssence/Menu/Team/MemberStatsMenu.cs
@@ -9,12 +9,12 @@ namespace RogueEssence.Menu
 {
     public class MemberStatsMenu : InteractableMenu
     {
-        Team team;
-        int teamSlot;
-        bool assembly;
-        bool allowAssembly;
-        bool guest;
-        bool boostView;
+        public Team team {get; private set;}
+        public int teamSlot {get; private set;}
+        public bool assembly {get; private set;}
+        public bool allowAssembly {get; private set;}
+        public bool guest {get; private set;}
+        public bool boostView {get; private set;}
 
         public MenuText Title;
         public MenuText PageText;

--- a/RogueEssence/Menu/Team/TeamChosenMenu.cs
+++ b/RogueEssence/Menu/Team/TeamChosenMenu.cs
@@ -12,7 +12,7 @@ namespace RogueEssence.Menu
     public class TeamChosenMenu : SingleStripMenu
     {
 
-        private int teamSlot;
+        public  int teamSlot {get; private set;}
 
         public TeamChosenMenu(int teamSlot) : this(MenuLabel.TEAM_CHOSEN_MENU, teamSlot) { }
         public TeamChosenMenu(string label, int teamSlot)

--- a/RogueEssence/Menu/Team/TeamMenu.cs
+++ b/RogueEssence/Menu/Team/TeamMenu.cs
@@ -16,7 +16,7 @@ namespace RogueEssence.Menu
 
         TeamMiniSummary summaryMenu;
 
-        bool sendHome;
+        public bool sendHome {get; private set;}
 
         public TeamMenu(bool sendHome) : this(sendHome, -1)
         { }


### PR DESCRIPTION
A few lists get deep copied when requested so that there is 0 risk of data tampering
Also contains a boolean fix i noticed was necessary