### PR TITLE
Improve Ground Editor tile authoring

### DIFF
--- a/RogueEssence.Editor.Avalonia/Converters/TileSizedConverter.cs
+++ b/RogueEssence.Editor.Avalonia/Converters/TileSizedConverter.cs
@@ -19,7 +19,8 @@ namespace RogueEssence.Dev.Converters
             {
                 bool useY = Boolean.Parse((string)parameter);
                 int diff = useY ? tileXY.Y : tileXY.X;
-                return diff * tileSize;
+                int zoomPercent = values.Count > 2 && values[2] is int zoom ? zoom : 100;
+                return diff * tileSize * zoomPercent / 100.0;
             }
             return 0;
         }

--- a/RogueEssence.Editor.Avalonia/Converters/TileToThicknessConverter.cs
+++ b/RogueEssence.Editor.Avalonia/Converters/TileToThicknessConverter.cs
@@ -15,7 +15,11 @@ namespace RogueEssence.Dev.Converters
         public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values[0] is TileFrame tileFrame && values[1] is int tileSize)
-                return new Thickness(tileFrame.TexLoc.X * tileSize, tileFrame.TexLoc.Y * tileSize, 0, 0);
+            {
+                int zoomPercent = values.Count > 2 && values[2] is int zoom ? zoom : 100;
+                double scaledTileSize = tileSize * zoomPercent / 100.0;
+                return new Thickness(tileFrame.TexLoc.X * scaledTileSize, tileFrame.TexLoc.Y * scaledTileSize, 0, 0);
+            }
             return new Thickness();
         }
     }

--- a/RogueEssence.Editor.Avalonia/Converters/TilesetScaledSizeConverter.cs
+++ b/RogueEssence.Editor.Avalonia/Converters/TilesetScaledSizeConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media.Imaging;
+
+namespace RogueEssence.Dev.Converters
+{
+    public class TilesetScaledSizeConverter : IMultiValueConverter
+    {
+        public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Count > 1 && values[0] is string tileset && !String.IsNullOrEmpty(tileset) && values[1] is int zoomPercent)
+            {
+                Bitmap bitmap = DevDataManager.GetTileset(tileset);
+                if (bitmap == null)
+                    return 0.0;
+                bool useHeight = Boolean.Parse((string)parameter);
+                int size = useHeight ? bitmap.PixelSize.Height : bitmap.PixelSize.Width;
+                return size * zoomPercent / 100.0;
+            }
+            return 0.0;
+        }
+    }
+}

--- a/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowser.axaml
+++ b/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowser.axaml
@@ -18,6 +18,7 @@
     <converters:TilesetConverter x:Key="TilesetConverter"/>
     <converters:FrameConverter x:Key="FrameConverter"/>
     <converters:MultiSelectConverter x:Key="MultiSelectConverter"/>
+    <converters:TilesetScaledSizeConverter x:Key="TilesetScaledSizeConverter"/>
   </UserControl.Resources>
   <Grid>
     <Grid.RowDefinitions>
@@ -67,31 +68,58 @@
         <Button Command="{Binding btnDeleteFrame_Click}" Margin="4,2" Grid.Row="3" Grid.Column="1">Delete</Button>
       </Grid>
     </Grid>
-    <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" Grid.Row="0" Grid.Column="0" Grid.RowSpan="3">
-      <Grid>
-        <Image Source="{Binding CurrentTileset, Converter={StaticResource TilesetConverter}}" PointerPressed="picTileset_Click" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0"/>
-        <Border VerticalAlignment="Top" HorizontalAlignment="Left" IsVisible="{Binding BorderPresent}" BorderThickness="1" BorderBrush="Red">
-          <Border.Margin>
-            <MultiBinding Converter="{StaticResource TileToThicknessConverter}">
-              <Binding Path="SelectedTile"/>
-              <Binding Path="TileSize"/>
-            </MultiBinding>
-          </Border.Margin>
-          <Border.Width>
-            <MultiBinding Converter="{StaticResource TileSizedConverter}" ConverterParameter="false">
-              <Binding Path="MultiSelect"/>
-              <Binding Path="TileSize"/>
-            </MultiBinding>
-          </Border.Width>
-          <Border.Height>
-            <MultiBinding Converter="{StaticResource TileSizedConverter}" ConverterParameter="true">
-              <Binding Path="MultiSelect"/>
-              <Binding Path="TileSize"/>
-            </MultiBinding>
-          </Border.Height>
-        </Border>
-      </Grid>
-    </ScrollViewer>
+    <Grid Grid.Row="0" Grid.Column="0" Grid.RowSpan="3">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition/>
+      </Grid.RowDefinitions>
+      <StackPanel Orientation="Horizontal" Margin="4,2">
+        <TextBlock VerticalAlignment="Center">Zoom:</TextBlock>
+        <NumericUpDown Value="{Binding ZoomPercent}" Minimum="50" Maximum="800" Increment="25" Width="82" Margin="6,0"/>
+        <TextBlock VerticalAlignment="Center">%  Left click: select tile  Right click: select second corner</TextBlock>
+      </StackPanel>
+      <ScrollViewer HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" Grid.Row="1">
+        <Grid>
+          <Image Source="{Binding CurrentTileset, Converter={StaticResource TilesetConverter}}" PointerPressed="picTileset_Click" VerticalAlignment="Top" HorizontalAlignment="Left" Stretch="Fill" Margin="0">
+            <Image.Width>
+              <MultiBinding Converter="{StaticResource TilesetScaledSizeConverter}" ConverterParameter="false">
+                <Binding Path="CurrentTileset"/>
+                <Binding Path="ZoomPercent"/>
+              </MultiBinding>
+            </Image.Width>
+            <Image.Height>
+              <MultiBinding Converter="{StaticResource TilesetScaledSizeConverter}" ConverterParameter="true">
+                <Binding Path="CurrentTileset"/>
+                <Binding Path="ZoomPercent"/>
+              </MultiBinding>
+            </Image.Height>
+          </Image>
+          <Border VerticalAlignment="Top" HorizontalAlignment="Left" IsVisible="{Binding BorderPresent}" BorderThickness="2" BorderBrush="Red">
+            <Border.Margin>
+              <MultiBinding Converter="{StaticResource TileToThicknessConverter}">
+                <Binding Path="SelectedTile"/>
+                <Binding Path="TileSize"/>
+                <Binding Path="ZoomPercent"/>
+              </MultiBinding>
+            </Border.Margin>
+            <Border.Width>
+              <MultiBinding Converter="{StaticResource TileSizedConverter}" ConverterParameter="false">
+                <Binding Path="MultiSelect"/>
+                <Binding Path="TileSize"/>
+                <Binding Path="ZoomPercent"/>
+              </MultiBinding>
+            </Border.Width>
+            <Border.Height>
+              <MultiBinding Converter="{StaticResource TileSizedConverter}" ConverterParameter="true">
+                <Binding Path="MultiSelect"/>
+                <Binding Path="TileSize"/>
+                <Binding Path="ZoomPercent"/>
+              </MultiBinding>
+            </Border.Height>
+          </Border>
+        </Grid>
+      </ScrollViewer>
+    </Grid>
     <views:SearchListBox DataContext="{Binding Tilesets}" Margin="4" Grid.Row="1" Grid.Column="1">
       <views:SearchListBox.ContextMenu>
         <ContextMenu>

--- a/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowser.axaml.cs
+++ b/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowser.axaml.cs
@@ -27,7 +27,8 @@ namespace RogueEssence.Dev.Views
             PointerPoint pt = e.GetCurrentPoint((IVisual)sender);
             TileBrowserViewModel vm = (TileBrowserViewModel)DataContext;
             
-            Loc clickedLoc = new Loc((int)pt.Position.X / vm.TileSize, (int)pt.Position.Y / vm.TileSize);
+            double scaledTileSize = vm.TileSize * vm.ZoomPercent / 100.0;
+            Loc clickedLoc = new Loc((int)(pt.Position.X / scaledTileSize), (int)(pt.Position.Y / scaledTileSize));
             vm.SelectTile(clickedLoc, pt.Properties.IsRightButtonPressed, (e.KeyModifiers & KeyModifiers.Shift) != KeyModifiers.None);
         }
     }

--- a/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowserViewModel.cs
+++ b/RogueEssence.Editor.Avalonia/DataEditor/Editors/RogueEssence/Tiles/TileBrowserViewModel.cs
@@ -201,6 +201,13 @@ namespace RogueEssence.Dev.ViewModels
             }
         }
 
+        private int zoomPercent = 200;
+        public int ZoomPercent
+        {
+            get => zoomPercent;
+            set => this.SetIfChanged(ref zoomPercent, Math.Max(50, Math.Min(800, value)));
+        }
+
         public bool CanMultiSelect;
 
 

--- a/RogueEssence.Editor.Avalonia/EditModes.cs
+++ b/RogueEssence.Editor.Avalonia/EditModes.cs
@@ -10,6 +10,8 @@ namespace RogueEssence.Dev
         Rectangle = 1,
         Fill = 2,
         Eyedrop = 3,
+        Copy = 4,
+        Paste = 5,
     }
 
     public enum EntEditMode

--- a/RogueEssence.Editor.Avalonia/ViewModels/GroundEditForm/GroundEditViewModel.cs
+++ b/RogueEssence.Editor.Avalonia/ViewModels/GroundEditForm/GroundEditViewModel.cs
@@ -332,6 +332,7 @@ namespace RogueEssence.Dev.ViewModels
 
         private void loadEditorSettings()
         {
+            Textures.CancelStroke();
             Textures.Layers.LoadLayers();
             Textures.TileBrowser.TileSize = ZoneManager.Instance.CurrentGround.TileSize;
             Textures.AutotileBrowser.TileSize = ZoneManager.Instance.CurrentGround.TileSize;
@@ -550,15 +551,19 @@ namespace RogueEssence.Dev.ViewModels
                 Decorations.TabbedOut();
             if (selectedTabIndex != 3)
                 Entities.TabbedOut();
+            if (selectedTabIndex != 0)
+                Textures.CancelStroke();
         }
 
         public void ProcessInput(InputManager input)
         {
             lock (GameBase.lockObj)
             {
-                if (input.BaseKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftControl))
+                bool controlDown = input.BaseKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftControl) || input.BaseKeyDown(Microsoft.Xna.Framework.Input.Keys.RightControl);
+                bool shiftDown = input.BaseKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift) || input.BaseKeyDown(Microsoft.Xna.Framework.Input.Keys.RightShift);
+                if (controlDown)
                 {
-                    if (input.BaseKeyPressed(Microsoft.Xna.Framework.Input.Keys.Z) && input.BaseKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftShift))
+                    if (input.BaseKeyPressed(Microsoft.Xna.Framework.Input.Keys.Z) && shiftDown)
                     {
                         mnuRedo_Click();
                         return;
@@ -566,6 +571,16 @@ namespace RogueEssence.Dev.ViewModels
                     else if (input.BaseKeyPressed(Microsoft.Xna.Framework.Input.Keys.Z))
                     {
                         mnuUndo_Click();
+                        return;
+                    }
+                    else if (selectedTabIndex == 0 && input.BaseKeyPressed(Microsoft.Xna.Framework.Input.Keys.C))
+                    {
+                        Textures.BeginCopy();
+                        return;
+                    }
+                    else if (selectedTabIndex == 0 && input.BaseKeyPressed(Microsoft.Xna.Framework.Input.Keys.V))
+                    {
+                        Textures.BeginPaste();
                         return;
                     }
                 }

--- a/RogueEssence.Editor.Avalonia/ViewModels/GroundEditForm/GroundTabTexturesViewModel.cs
+++ b/RogueEssence.Editor.Avalonia/ViewModels/GroundEditForm/GroundTabTexturesViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using RogueElements;
 using RogueEssence.Content;
 using RogueEssence.Dungeon;
+using ReactiveUI;
 using System;
 using System.Collections.Generic;
 
@@ -16,13 +17,16 @@ namespace RogueEssence.Dev.ViewModels
             AutotileBrowser = new AutotileBrowserViewModel();
         }
 
+        private AutoTile[][] copiedRegion;
+
         private TileEditMode texMode;
         public TileEditMode TexMode
         {
             get { return texMode; }
             set
             {
-                this.SetIfChanged(ref texMode, value);
+                if (this.SetIfChanged(ref texMode, value))
+                    CancelStroke();
             }
         }
 
@@ -39,7 +43,8 @@ namespace RogueEssence.Dev.ViewModels
             get => tabIndex;
             set
             {
-                this.SetIfChanged(ref tabIndex, value);
+                if (this.SetIfChanged(ref tabIndex, value))
+                    CancelStroke();
             }
         }
 
@@ -110,7 +115,79 @@ namespace RogueEssence.Dev.ViewModels
                             eyedropTile(tileCoords);
                     }
                     break;
+                case TileEditMode.Copy:
+                    {
+                        CanvasStroke<bool>.ProcessCanvasInput(input, tileCoords, inWindow,
+                            () => new RectStroke<bool>(tileCoords, true),
+                            () => null,
+                            copyRegion, ref GroundEditScene.Instance.TextureSelectionInProgress);
+                    }
+                    break;
+                case TileEditMode.Paste:
+                    {
+                        CanvasStroke<AutoTile>.ProcessCanvasInput(input, tileCoords, inWindow,
+                            () => copiedRegion == null ? null : new ClusterStroke<AutoTile>(tileCoords, copiedRegion),
+                            () => null,
+                            paintStroke, ref GroundEditScene.Instance.AutoTileInProgress);
+                    }
+                    break;
             }
+        }
+
+        public bool CanPaste => copiedRegion != null;
+
+        public string CopyStatus
+        {
+            get
+            {
+                if (copiedRegion == null)
+                    return "Ctrl+C: drag a region on the map  Ctrl+V: paste it";
+                return String.Format("Copied {0} x {1} tiles from the active texture layer", copiedRegion.Length, copiedRegion[0].Length);
+            }
+        }
+
+        public void BeginCopy()
+        {
+            TexMode = TileEditMode.Copy;
+            CancelStroke();
+        }
+
+        public void BeginPaste()
+        {
+            if (copiedRegion == null)
+                return;
+
+            TexMode = TileEditMode.Paste;
+            CancelStroke();
+        }
+
+        public void CancelStroke()
+        {
+            GroundEditScene.Instance.AutoTileInProgress = null;
+            GroundEditScene.Instance.TextureSelectionInProgress = null;
+        }
+
+        private void copyRegion(CanvasStroke<bool> stroke)
+        {
+            Rect mapBounds = new Rect(0, 0, ZoneManager.Instance.CurrentGround.Width, ZoneManager.Instance.CurrentGround.Height);
+            Rect selected = Rect.Intersect(stroke.CoveredRect, mapBounds);
+            if (selected.Size.X <= 0 || selected.Size.Y <= 0)
+                return;
+
+            copiedRegion = new AutoTile[selected.Size.X][];
+            for (int xx = 0; xx < selected.Size.X; xx++)
+            {
+                copiedRegion[xx] = new AutoTile[selected.Size.Y];
+                for (int yy = 0; yy < selected.Size.Y; yy++)
+                {
+                    AutoTile tile = ZoneManager.Instance.CurrentGround.Layers[Layers.ChosenLayer].Tiles[selected.X + xx][selected.Y + yy];
+                    copiedRegion[xx][yy] = tile.Copy();
+                }
+            }
+
+            this.RaisePropertyChanged(nameof(CanPaste));
+            this.RaisePropertyChanged(nameof(CopyStatus));
+            TexMode = TileEditMode.Paste;
         }
 
 
@@ -137,15 +214,18 @@ namespace RogueEssence.Dev.ViewModels
         private void paintStroke(CanvasStroke<AutoTile> stroke)
         {
             Dictionary<Loc, AutoTile> brush = new Dictionary<Loc, AutoTile>();
+            Rect appliedBounds = new Rect();
             foreach (Loc loc in stroke.GetLocs())
             {
                 if (!Collision.InBounds(ZoneManager.Instance.CurrentGround.Width, ZoneManager.Instance.CurrentGround.Height, loc))
                     continue;
 
+                appliedBounds = brush.Count == 0 ? Rect.FromPoint(loc) : Rect.IncludeLoc(appliedBounds, loc);
                 brush[loc] = stroke.GetBrush(loc).Copy();
             }
 
-            DiagManager.Instance.DevEditor.GroundEditor.Edits.Apply(new DrawGroundTexUndo(Layers.ChosenLayer, brush, stroke.CoveredRect));
+            if (brush.Count > 0)
+                DiagManager.Instance.DevEditor.GroundEditor.Edits.Apply(new DrawGroundTexUndo(Layers.ChosenLayer, brush, appliedBounds));
         }
 
         private void eyedropTile(Loc loc)

--- a/RogueEssence.Editor.Avalonia/Views/GroundEditForm/GroundTabTextures.axaml
+++ b/RogueEssence.Editor.Avalonia/Views/GroundEditForm/GroundTabTextures.axaml
@@ -16,7 +16,7 @@
   </UserControl.Resources>
   <Grid Margin="4" >
     <Grid.RowDefinitions>
-      <RowDefinition Height="38"/>
+      <RowDefinition Height="58"/>
       <RowDefinition/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
@@ -28,8 +28,11 @@
       <Grid.RowDefinitions>
         <RowDefinition Height="16"/>
         <RowDefinition Height="26"/>
+        <RowDefinition Height="16"/>
       </Grid.RowDefinitions>
       <Grid.ColumnDefinitions>
+        <ColumnDefinition/>
+        <ColumnDefinition/>
         <ColumnDefinition/>
         <ColumnDefinition/>
         <ColumnDefinition/>
@@ -40,6 +43,9 @@
       <RadioButton IsChecked="{Binding Path=TexMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static local:TileEditMode.Rectangle}}" VerticalAlignment="Top" Margin="2" Grid.Row="1" Grid.Column="1">Rectangle</RadioButton>
       <RadioButton IsChecked="{Binding Path=TexMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static local:TileEditMode.Fill}}" VerticalAlignment="Top" Margin="2" Grid.Row="1" Grid.Column="2">Fill</RadioButton>
       <RadioButton IsChecked="{Binding Path=TexMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static local:TileEditMode.Eyedrop}}" VerticalAlignment="Top" Margin="2" Grid.Row="1" Grid.Column="3">Eyedrop</RadioButton>
+      <RadioButton IsChecked="{Binding Path=TexMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static local:TileEditMode.Copy}}" VerticalAlignment="Top" Margin="2" Grid.Row="1" Grid.Column="4">Copy region</RadioButton>
+      <RadioButton IsChecked="{Binding Path=TexMode, Converter={StaticResource ComparisonConverter}, ConverterParameter={x:Static local:TileEditMode.Paste}}" IsEnabled="{Binding CanPaste}" VerticalAlignment="Top" Margin="2" Grid.Row="1" Grid.Column="5">Paste region</RadioButton>
+      <TextBlock Text="{Binding CopyStatus}" Margin="4,0" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="6"/>
     </Grid>
     <TabControl TabStripPlacement="Top" SelectedIndex="{Binding TabIndex}" Margin="4" Grid.Row="1" Grid.Column="1">
       <TabItem Header="Tiles" >

--- a/RogueEssence/Dev/GroundEditScene.cs
+++ b/RogueEssence/Dev/GroundEditScene.cs
@@ -45,6 +45,10 @@ namespace RogueEssence.Dev
         public EditorMode EditMode;
 
         public CanvasStroke<AutoTile> AutoTileInProgress;
+        /// <summary>
+        /// The texture-region selection currently previewed by the ground editor.
+        /// </summary>
+        public CanvasStroke<bool> TextureSelectionInProgress;
         public CanvasStroke<bool> BlockInProgress;
         public GroundAnim DecorationInProgress;
         public GroundEntity EntityInProgress;
@@ -170,6 +174,24 @@ namespace RogueEssence.Dev
                                     GraphicsManager.Pixel.Draw(spriteBatch, new Rectangle(ii * ZoneManager.Instance.CurrentGround.TileSize - ViewRect.X, jj * ZoneManager.Instance.CurrentGround.TileSize - ViewRect.Y, ZoneManager.Instance.CurrentGround.TileSize, ZoneManager.Instance.CurrentGround.TileSize), null, Color.Black);
                                 else
                                     brush.Draw(spriteBatch, new Loc(ii * ZoneManager.Instance.CurrentGround.TileSize, jj * ZoneManager.Instance.CurrentGround.TileSize) - ViewRect.Start);
+                            }
+                        }
+                    }
+                }
+
+                if (TextureSelectionInProgress != null)
+                {
+                    for (int jj = viewTileRect.Y; jj < viewTileRect.End.Y; jj++)
+                    {
+                        for (int ii = viewTileRect.X; ii < viewTileRect.End.X; ii++)
+                        {
+                            Loc testLoc = new Loc(ii, jj);
+                            if (Collision.InBounds(ZoneManager.Instance.CurrentGround.Width, ZoneManager.Instance.CurrentGround.Height, testLoc) &&
+                                TextureSelectionInProgress.IncludesLoc(testLoc))
+                            {
+                                GraphicsManager.Pixel.Draw(spriteBatch, new Rectangle(ii * ZoneManager.Instance.CurrentGround.TileSize - ViewRect.X,
+                                    jj * ZoneManager.Instance.CurrentGround.TileSize - ViewRect.Y,
+                                    ZoneManager.Instance.CurrentGround.TileSize, ZoneManager.Instance.CurrentGround.TileSize), null, Color.White * 0.5f);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

This improves two common Ground Editor tile-authoring workflows:

- Add a zoom control to the shared Tile Browser, from 50% to 800% with a 200% default.
- Keep tile hit testing, the selected-tile border, and multi-tile selections aligned at every zoom level.
- Add rectangular copy and paste tools for Ground Map texture layers.
- Preserve copied regions across layers and maps for the current editor session without serializing clipboard state.
- Clip copied and pasted regions to map bounds and apply each paste as one existing undo step.
- Add Ctrl+C and Ctrl+V shortcuts, with both Control keys supported. Undo and redo now also recognize both Control and Shift keys.
- Use a dedicated translucent selection preview instead of rendering copied selections as erased tiles.

## Why

Large tilesets are difficult to inspect at their native size, and recreating repeated Ground Map texture arrangements tile by tile is slow. These changes keep the existing editor model and undo system while making both tasks faster.

## Usage

- Change the Tile Browser zoom with the percentage control above the tileset.
- Select **Copy region** or press **Ctrl+C**, then drag over the Ground Map.
- Select **Paste region** or press **Ctrl+V**, then place the copied region.
- Each completed paste is a single undoable edit.

## Validation

- `dotnet build RogueEssence.sln -c Debug --no-restore`
- `dotnet build RogueEssence.sln -c Release --no-restore`
- Focused validation for reverse-direction rectangle selection, cluster/paste offsets, zoom scaling, and the converters' 100% compatibility fallback
- `git diff --check`
- Independent final review for clipping, undo behavior, deep copies, shortcut handling, session clipboard behavior, and MVVM bindings

The full solution builds with no errors. Existing repository warnings remain; the new members introduce no additional warnings.

## Draft follow-up

The original workflow has been used interactively while authoring a mod. I am leaving this PR as a draft until I add a final interactive pass and screenshots for this cleaned upstream version.

## AI disclosure

The implementation was produced with OpenAI Codex under my direction. I reviewed the final changes against the existing RogueEssence code and previously accepted contributions, and I welcome experienced upstream review.
