### PR TITLE
Add methods to set pitch of music and sounds

### DIFF
--- a/RogueEssence/Content/LoopedSong.cs
+++ b/RogueEssence/Content/LoopedSong.cs
@@ -22,6 +22,12 @@ namespace RogueEssence.Content
             set { soundStream.Volume = value; }
         }
 
+        public float Pitch
+        {
+            get { return soundStream.Pitch; }
+            set { soundStream.Pitch = value; }
+        }
+
         public SoundState State { get { return soundStream.State; } }
 
         public int Channels { get; private set; }

--- a/RogueEssence/Content/SoundManager.cs
+++ b/RogueEssence/Content/SoundManager.cs
@@ -21,6 +21,7 @@ namespace RogueEssence.Content
         static TimeSpan currentTime;
 
         static float bgmVol;
+        static float bgmPitch;
 
         static Dictionary<string, SongSetting> songs;
 
@@ -72,6 +73,7 @@ namespace RogueEssence.Content
                 songs.Add(fileName, new SongSetting(song, volume));
             }
             updateSongVolume();
+            updateSongPitch();
 
             foreach (SongSetting song in songs.Values)
             {
@@ -99,8 +101,20 @@ namespace RogueEssence.Content
                 song.Song.Volume = bgmVol * BGMBalance * (float)Math.Log10(song.CrossVolume * 9f + 1f);
         }
 
+        public static void SetBGMPitch(float pitch)
+        {
+            bgmPitch = pitch;
+            updateSongPitch();
+        }
 
-        public static void PlayLoopedSE(string fileName, float volume = 1.0f)
+        private static void updateSongPitch()
+        {
+            foreach (SongSetting song in songs.Values)
+                song.Song.Pitch = bgmPitch;
+        }
+
+
+        public static void PlayLoopedSE(string fileName, float volume = 1.0f, float pitch = 0.0f)
         {
             if (loopedSE.ContainsKey(fileName))
                 return;
@@ -111,6 +125,7 @@ namespace RogueEssence.Content
                 se.Play();
                 float seVol = volume;
                 se.Volume = seVol * seVol;
+                se.Pitch = pitch;
                 loopedSE.Add(fileName, se);
             }
         }
@@ -137,6 +152,13 @@ namespace RogueEssence.Content
             LoopedSong se;
             if (loopedSE.TryGetValue(fileName, out se))
                 se.Volume = volume * SEBalance;
+        }
+
+        public static void SetLoopedSEPitch(string fileName, float pitch)
+        {
+            LoopedSong se;
+            if (loopedSE.TryGetValue(fileName, out se))
+                se.Pitch = pitch;
         }
 
         public static void NewFrame(GameTime gameTime)
@@ -168,7 +190,7 @@ namespace RogueEssence.Content
 
 
 
-        public static int PlaySound(string fileName, float volume = 1.0f)
+        public static int PlaySound(string fileName, float volume = 1.0f, float pitch = 0.0f)
         {
             if (volume * seBalance <= 0f)
                 return 0;
@@ -192,6 +214,7 @@ namespace RogueEssence.Content
 
             long total_samples = FAudio.stb_vorbis_stream_length_in_samples(stbVorbisData);
             long total_frames = total_samples * 60 / fileInfo.sample_rate;
+            if (pitch != 0.0f) total_frames = Convert.ToInt64(total_frames / Math.Pow(2.0f, pitch));
             float[] chunk = new float[fileInfo.channels * total_samples];
             int framesRead = FAudio.stb_vorbis_get_samples_float_interleaved(stbVorbisData, fileInfo.channels, chunk, fileInfo.channels * (int)total_samples);
             FAudio.stb_vorbis_close(stbVorbisData);
@@ -202,6 +225,7 @@ namespace RogueEssence.Content
                 (fileInfo.channels == 1) ? AudioChannels.Mono : AudioChannels.Stereo
             );
             soundStream.Volume = volume * seBalance;
+            soundStream.Pitch = pitch;
             soundStream.SubmitFloatBufferEXT(chunk, 0, framesRead * fileInfo.channels);
             soundStream.Play();
             sounds.Add(soundStream);

--- a/RogueEssence/Scene/GameManager.cs
+++ b/RogueEssence/Scene/GameManager.cs
@@ -117,13 +117,17 @@ namespace RogueEssence
                 false, GraphicsManager.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.Depth24Stencil8);
         }
 
-        public void BattleSE(string newSE)
+        public void BattleSE(string newSE) { BattleSE(newSE, 1.0f, 0.0f); }
+        public void BattleSE(string newSE, float volume) { BattleSE(newSE, volume, 0.0f); }
+        public void BattleSE(string newSE, float volume, float pitch)
         {
             if (newSE != "")
-                SE("Battle/" + newSE);
+                SE("Battle/" + newSE, volume, pitch);
         }
 
-        public void SE(string newSE)
+        public void SE(string newSE) { SE(newSE, 1.0f, 0.0f); }
+        public void SE(string newSE, float volume) { SE(newSE, volume, 0.0f); }
+        public void SE(string newSE, float volume, float pitch)
         {
             try
             {
@@ -131,7 +135,7 @@ namespace RogueEssence
                     return;
 
                 if (System.IO.File.Exists(PathMod.ModPath(GraphicsManager.SOUND_PATH + newSE + ".ogg")))
-                    SoundManager.PlaySound(PathMod.ModPath(GraphicsManager.SOUND_PATH + newSE + ".ogg"), 1);
+                    SoundManager.PlaySound(PathMod.ModPath(GraphicsManager.SOUND_PATH + newSE + ".ogg"), Math.Clamp(volume, 0.0f, 1.0f), pitch);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Additionally, overloads for `GameManager.SE` and `GameManager.BattleSE` have been included to support `volume` and `pitch` parameters.

Pitch is [limited by FNA,](https://github.com/FNA-XNA/FNA/blob/e4ab6933a32f0be5791dd4cd4e616993fed609a8/src/Audio/SoundEffectInstance.cs#L95) clamped between -1.0 (-1 octave/50% speed) and +1.0 (+1 octave/200% speed).