### PR TITLE
Count immobilized movement taps as turns

### DIFF
--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -553,6 +553,10 @@ namespace RogueEssence.Dungeon
                             if (losTarget != Dir8.None && losTarget != FocusedCharacter.CharDir)
                                 action = new GameAction(GameAction.ActionType.Dir, losTarget);
                         }
+                        //An immobilized character treats the initial movement press as a wait.
+                        //Holding the direction does not keep advancing turns.
+                        else if (FocusedCharacter.CantWalk && input.Direction != Dir8.None && input.Direction != input.PrevDirection)
+                            action = new GameAction(GameAction.ActionType.Wait, Dir8.None);
                         else if (input.Direction != Dir8.None)
                         {
                             //only move on an empty stomach when the key is pressed, not held


### PR DESCRIPTION
## Summary

- treat the first directional press while the focused character cannot walk as a wait action
- compare the current and previous directions so a held input does not repeatedly advance turns
- keep the existing turn-in-place modifier behavior unchanged

## Motivation

Paralysis and other immobilizing states require an action to advance the turn, but attempting to move was previously ignored. This makes a deliberate movement tap behave like the other turn-consuming inputs without turning a held direction into an automatic wait loop.

## Testing

- `dotnet build RogueEssence/RogueEssence.csproj --configuration Release --no-restore`
- EOTA regression applies the change from a clean baseline and asserts the `CantWalk` plus direction-edge contract
