### PR TITLE
Add a registered throwable shortcut

### DIFF
--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -486,7 +486,15 @@ namespace RogueEssence.Dungeon
                         ProcessMinimapInput(input);
                     else if (input[FrameInput.InputType.Skills])
                     {
-                        if (input[FrameInput.InputType.SkillPreview])
+                        if (!String.IsNullOrEmpty(ActiveTeam.RegisteredItem) && input.JustPressed(FrameInput.InputType.SkillPreview))
+                        {
+                            int itemSlot = ActiveTeam.GetRegisteredItemSlot();
+                            if (itemSlot > -1)
+                                action = new GameAction(GameAction.ActionType.Throw, Dir8.None, itemSlot);
+                            else
+                                GameManager.Instance.SE("Menu/Cancel");
+                        }
+                        else if (String.IsNullOrEmpty(ActiveTeam.RegisteredItem) && input[FrameInput.InputType.SkillPreview])
                         {
                             previewing = true;
                             int skillIndex = ProcessSkillInput(input, true);

--- a/RogueEssence/Dungeon/DungeonScene.cs
+++ b/RogueEssence/Dungeon/DungeonScene.cs
@@ -494,7 +494,7 @@ namespace RogueEssence.Dungeon
                             else
                                 GameManager.Instance.SE("Menu/Cancel");
                         }
-                        else if (String.IsNullOrEmpty(ActiveTeam.RegisteredItem) && input[FrameInput.InputType.SkillPreview])
+                        else if (input[FrameInput.InputType.LeaderSwapForth])
                         {
                             previewing = true;
                             int skillIndex = ProcessSkillInput(input, true);

--- a/RogueEssence/Dungeon/Team.cs
+++ b/RogueEssence/Dungeon/Team.cs
@@ -400,6 +400,10 @@ namespace RogueEssence.Dungeon
 
         public int MaxInv;
 
+        [JsonConverter(typeof(ItemConverter))]
+        [DataType(0, DataManager.DataType.Item, false)]
+        public string RegisteredItem;
+
         public EventedList<Character> Assembly;
 
         [JsonConverter(typeof(ItemStorageConverter))]
@@ -425,6 +429,7 @@ namespace RogueEssence.Dungeon
         [JsonConstructor]
         public ExplorerTeam(bool initEvents) : base()
         {
+            RegisteredItem = "";
             Assembly = new EventedList<Character>();
             BoxStorage = new List<InvItem>();
             Storage = new Dictionary<string, int>();
@@ -437,6 +442,7 @@ namespace RogueEssence.Dungeon
         protected ExplorerTeam(ExplorerTeam other) : base(other)
         {
             MaxInv = other.MaxInv;
+            RegisteredItem = other.RegisteredItem;
 
             Assembly = new EventedList<Character>();
             foreach (Character chara in other.Assembly)
@@ -460,6 +466,19 @@ namespace RogueEssence.Dungeon
         }
 
         public override Team Clone() { return new ExplorerTeam(this); }
+
+        public int GetRegisteredItemSlot()
+        {
+            if (String.IsNullOrEmpty(RegisteredItem))
+                return -1;
+
+            for (int ii = 0; ii < GetInvCount(); ii++)
+            {
+                if (GetInv(ii).ID == RegisteredItem)
+                    return ii;
+            }
+            return -1;
+        }
 
         public void SetRank(string rank)
         {

--- a/RogueEssence/Menu/Items/ItemChosenMenu.cs
+++ b/RogueEssence/Menu/Items/ItemChosenMenu.cs
@@ -191,6 +191,11 @@ namespace RogueEssence.Menu
                         choices.Add(new MenuTextChoice(Text.FormatKey("MENU_ITEM_THROW"), ThrowAction));
                 }
             }
+            if (!held && entry.UsageType == ItemData.UseType.Throw)
+            {
+                bool registered = DataManager.Instance.Save.ActiveTeam.RegisteredItem == invItem.ID;
+                choices.Add(new MenuTextChoice(Text.FormatKey(registered ? "MENU_FAVORITE_OFF" : "MENU_FAVORITE"), RegisterAction));
+            }
             if (entry.UsageType == ItemData.UseType.Learn)
                 choices.Add(new MenuTextChoice(Text.FormatKey("MENU_INFO"), InfoAction));
             if (GameManager.Instance.CurrentScene != DungeonScene.Instance)
@@ -270,6 +275,14 @@ namespace RogueEssence.Menu
         {
             MenuManager.Instance.ClearMenus();
             MenuManager.Instance.EndAction = DungeonScene.Instance.ProcessPlayerInput(new GameAction(GameAction.ActionType.Throw, Dir8.None, getItemUseSlot()));
+        }
+
+        private void RegisterAction()
+        {
+            ExplorerTeam team = DataManager.Instance.Save.ActiveTeam;
+            InvItem item = team.GetInv(slot);
+            team.RegisteredItem = team.RegisteredItem == item.ID ? "" : item.ID;
+            MenuManager.Instance.RemoveMenu();
         }
 
         private void InfoAction()

--- a/RogueEssence/Menu/Notices/HotkeyMenu.cs
+++ b/RogueEssence/Menu/Notices/HotkeyMenu.cs
@@ -107,15 +107,16 @@ namespace RogueEssence.Menu
         public void UpdateControls()
         {
             ExplorerTeam team = DataManager.Instance.Save.ActiveTeam;
-            string control = DiagManager.Instance.GetControlString(FrameInput.InputType.SkillPreview);
+            string previewControl = DiagManager.Instance.GetControlString(FrameInput.InputType.LeaderSwapForth);
+            string controlText = previewControl + " [color=#FFFF00]" + Text.FormatKey("MENU_SKILL_PREVIEW") + "[color]";
             if (!String.IsNullOrEmpty(team.RegisteredItem))
             {
                 int itemSlot = team.GetRegisteredItemSlot();
                 InvItem item = itemSlot > -1 ? team.GetInv(itemSlot) : new InvItem(team.RegisteredItem, false, 0);
-                menuText.SetText(control + ": " + item.GetDisplayName());
+                string itemControl = DiagManager.Instance.GetControlString(FrameInput.InputType.SkillPreview);
+                controlText += " | " + itemControl + ": " + item.GetDisplayName();
             }
-            else
-                menuText.SetText(control + " [color=#FFFF00]" + Text.FormatKey("MENU_SKILL_PREVIEW") + "[color]");
+            menuText.SetText(controlText);
             int textLength = MathUtils.DivUp(menuText.GetTextLength(), 4) * 4;
             Bounds = Rect.FromPoints(new Loc(GraphicsManager.ScreenWidth - textLength - 16 - GraphicsManager.MenuBG.TileWidth, 24), new Loc(GraphicsManager.ScreenWidth + GraphicsManager.MenuBG.TileWidth, 24 + LINE_HEIGHT + GraphicsManager.MenuBG.TileHeight * 2));
             menuText.Loc = new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight);

--- a/RogueEssence/Menu/Notices/HotkeyMenu.cs
+++ b/RogueEssence/Menu/Notices/HotkeyMenu.cs
@@ -4,6 +4,7 @@ using RogueElements;
 using Microsoft.Xna.Framework;
 using RogueEssence.Content;
 using RogueEssence.Data;
+using RogueEssence.Dungeon;
 
 namespace RogueEssence.Menu
 {
@@ -105,7 +106,16 @@ namespace RogueEssence.Menu
 
         public void UpdateControls()
         {
-            menuText.SetText(DiagManager.Instance.GetControlString(FrameInput.InputType.SkillPreview) + " [color=#FFFF00]" + Text.FormatKey("MENU_SKILL_PREVIEW") + "[color]");
+            ExplorerTeam team = DataManager.Instance.Save.ActiveTeam;
+            string control = DiagManager.Instance.GetControlString(FrameInput.InputType.SkillPreview);
+            if (!String.IsNullOrEmpty(team.RegisteredItem))
+            {
+                int itemSlot = team.GetRegisteredItemSlot();
+                InvItem item = itemSlot > -1 ? team.GetInv(itemSlot) : new InvItem(team.RegisteredItem, false, 0);
+                menuText.SetText(control + ": " + item.GetDisplayName());
+            }
+            else
+                menuText.SetText(control + " [color=#FFFF00]" + Text.FormatKey("MENU_SKILL_PREVIEW") + "[color]");
             int textLength = MathUtils.DivUp(menuText.GetTextLength(), 4) * 4;
             Bounds = Rect.FromPoints(new Loc(GraphicsManager.ScreenWidth - textLength - 16 - GraphicsManager.MenuBG.TileWidth, 24), new Loc(GraphicsManager.ScreenWidth + GraphicsManager.MenuBG.TileWidth, 24 + LINE_HEIGHT + GraphicsManager.MenuBG.TileHeight * 2));
             menuText.Loc = new Loc(Bounds.Width - GraphicsManager.MenuBG.TileWidth * 2, GraphicsManager.MenuBG.TileHeight);


### PR DESCRIPTION
## Summary

- allow one throwable bag item to be favorited as the registered quick item
- while the skills overlay is held, throw that item on a fresh Skill Preview/ZR press (`ZL + ZR` on the default controller mapping)
- move skill preview to Leader Swap Forth/R while the overlay is held (`ZL + R`)
- show both controls in the overlay when a throwable is registered
- preserve the existing `R`-alone leader swap outside the overlay

## Details

The selection is saved by item ID rather than inventory slot, so sorting or stack movement does not invalidate it. If the item is temporarily absent, the selection remains for later reacquisition and the shortcut plays the normal cancel sound instead of consuming a turn.

Existing `MENU_FAVORITE` and `MENU_FAVORITE_OFF` strings are reused, so this does not add a localization dependency.

The quick throw only reacts to a newly pressed ZR input. Holding the button does not repeatedly throw items. Skill preview uses R only while the ZL skills overlay is active, where normal leader swapping is already suppressed.

## Testing

- `dotnet build RogueEssence/RogueEssence.csproj --configuration Release --no-restore`
- EOTA regression applies the change from a clean baseline and verifies `ZL + ZR` quick throw, `ZL + R` skill preview, unchanged `R`-alone leader swap, save/menu behavior, overlay labels, and the `JustPressed` quick-throw contract
